### PR TITLE
Bottom Navigation 디자인 스팩에 맞춰 변경 && Theme Color 일부 세팅

### DIFF
--- a/app/src/main/java/com/soopeach/dowith/ui/AppScreen.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/AppScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -21,6 +22,8 @@ import com.soopeach.dowith.ui.screen.personal.PersonalTodoScreen
 import com.soopeach.dowith.ui.screen.Screen
 import com.soopeach.dowith.ui.screen.Screen.Companion.bottomNavigationItems
 import com.soopeach.dowith.ui.screen.team.TeamTodoScreen
+import com.soopeach.dowith.ui.theme.DoWithColors
+import com.soopeach.dowith.ui.theme.DoWithTypography
 
 @Composable
 fun AppScreen() {
@@ -34,13 +37,20 @@ fun AppScreen() {
             val currentDestination = navBackStackEntry?.destination
 
             if (currentDestination?.route in bottomNavigationItems.map { it.route }) {
-                BottomNavigation() {
+                BottomNavigation(
+                    backgroundColor = Color.White,
+                ) {
                     bottomNavigationItems.forEach { screen ->
                         BottomNavigationItem(
                             icon = {
                                 Icon(requireNotNull(screen.icon), contentDescription = null)
                             },
-                            label = { Text(stringResource(requireNotNull(screen.resourceId))) },
+                            label = {
+                                Text(
+                                    text = stringResource(requireNotNull(screen.resourceId)),
+                                    style = DoWithTypography.Caption1
+                                )
+                            },
                             selected = currentDestination?.hierarchy?.any { it.route == screen.route } == true,
                             onClick = {
                                 navController.navigate(screen.route) {
@@ -50,7 +60,9 @@ fun AppScreen() {
                                     launchSingleTop = true
                                     restoreState = true
                                 }
-                            }
+                            },
+                            selectedContentColor = DoWithColors.orange1000,
+                            unselectedContentColor = DoWithColors.gray400
                         )
                     }
                 }

--- a/app/src/main/java/com/soopeach/dowith/ui/icons/menu/DoneMenu.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/icons/menu/DoneMenu.kt
@@ -1,0 +1,89 @@
+package com.soopeach.dowith.ui.icons.menu
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val DoneMenu: ImageVector
+    get() {
+        if (_doneMenu != null) {
+            return requireNotNull(_doneMenu)
+        }
+        _doneMenu = Builder(name = "DoneMenu", defaultWidth = 26.0.dp, defaultHeight = 26.0.dp,
+                viewportWidth = 26.0f, viewportHeight = 26.0f).apply {
+            path(fill = SolidColor(Color(0xFFB7B7B7)), stroke = null, strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                    pathFillType = NonZero) {
+                moveTo(13.8125f, 8.125f)
+                verticalLineTo(12.5399f)
+                lineTo(17.4809f, 14.7408f)
+                curveTo(17.6657f, 14.8518f, 17.7988f, 15.0316f, 17.851f, 15.2407f)
+                curveTo(17.9032f, 15.4499f, 17.8702f, 15.6712f, 17.7592f, 15.8559f)
+                curveTo(17.6482f, 16.0407f, 17.4684f, 16.1738f, 17.2593f, 16.226f)
+                curveTo(17.0501f, 16.2782f, 16.8288f, 16.2452f, 16.6441f, 16.1342f)
+                lineTo(12.5816f, 13.6967f)
+                curveTo(12.4613f, 13.6245f, 12.3618f, 13.5223f, 12.2928f, 13.4003f)
+                curveTo(12.2237f, 13.2782f, 12.1875f, 13.1403f, 12.1875f, 13.0f)
+                verticalLineTo(8.125f)
+                curveTo(12.1875f, 7.9095f, 12.2731f, 7.7028f, 12.4255f, 7.5505f)
+                curveTo(12.5778f, 7.3981f, 12.7845f, 7.3125f, 13.0f, 7.3125f)
+                curveTo(13.2155f, 7.3125f, 13.4222f, 7.3981f, 13.5745f, 7.5505f)
+                curveTo(13.7269f, 7.7028f, 13.8125f, 7.9095f, 13.8125f, 8.125f)
+                close()
+                moveTo(13.0f, 3.25f)
+                curveTo(11.7183f, 3.2468f, 10.4486f, 3.4978f, 9.2646f, 3.9886f)
+                curveTo(8.0805f, 4.4793f, 7.0055f, 5.2f, 6.1019f, 6.109f)
+                curveTo(5.3635f, 6.8565f, 4.7074f, 7.5756f, 4.0625f, 8.3281f)
+                verticalLineTo(6.5f)
+                curveTo(4.0625f, 6.2845f, 3.9769f, 6.0778f, 3.8245f, 5.9255f)
+                curveTo(3.6721f, 5.7731f, 3.4655f, 5.6875f, 3.25f, 5.6875f)
+                curveTo(3.0345f, 5.6875f, 2.8279f, 5.7731f, 2.6755f, 5.9255f)
+                curveTo(2.5231f, 6.0778f, 2.4375f, 6.2845f, 2.4375f, 6.5f)
+                verticalLineTo(10.5625f)
+                curveTo(2.4375f, 10.778f, 2.5231f, 10.9847f, 2.6755f, 11.137f)
+                curveTo(2.8279f, 11.2894f, 3.0345f, 11.375f, 3.25f, 11.375f)
+                horizontalLineTo(7.3125f)
+                curveTo(7.528f, 11.375f, 7.7347f, 11.2894f, 7.887f, 11.137f)
+                curveTo(8.0394f, 10.9847f, 8.125f, 10.778f, 8.125f, 10.5625f)
+                curveTo(8.125f, 10.347f, 8.0394f, 10.1403f, 7.887f, 9.988f)
+                curveTo(7.7347f, 9.8356f, 7.528f, 9.75f, 7.3125f, 9.75f)
+                horizontalLineTo(4.9766f)
+                curveTo(5.7027f, 8.8948f, 6.4259f, 8.0894f, 7.2505f, 7.2546f)
+                curveTo(8.3798f, 6.1254f, 9.8167f, 5.354f, 11.3819f, 5.0368f)
+                curveTo(12.947f, 4.7196f, 14.5709f, 4.8706f, 16.0507f, 5.4711f)
+                curveTo(17.5305f, 6.0715f, 18.8005f, 7.0947f, 19.7021f, 8.4128f)
+                curveTo(20.6037f, 9.731f, 21.0968f, 11.2855f, 21.1199f, 12.8823f)
+                curveTo(21.143f, 14.4791f, 20.6951f, 16.0473f, 19.832f, 17.391f)
+                curveTo(18.9689f, 18.7346f, 17.729f, 19.7942f, 16.2672f, 20.4372f)
+                curveTo(14.8054f, 21.0802f, 13.1866f, 21.2781f, 11.6129f, 21.0063f)
+                curveTo(10.0392f, 20.7345f, 8.5806f, 20.005f, 7.4191f, 18.9089f)
+                curveTo(7.3415f, 18.8355f, 7.2502f, 18.7782f, 7.1504f, 18.7401f)
+                curveTo(7.0506f, 18.7021f, 6.9443f, 18.684f, 6.8376f, 18.687f)
+                curveTo(6.7308f, 18.6901f, 6.6257f, 18.7141f, 6.5282f, 18.7577f)
+                curveTo(6.4307f, 18.8014f, 6.3428f, 18.8638f, 6.2695f, 18.9414f)
+                curveTo(6.1961f, 19.019f, 6.1388f, 19.1103f, 6.1007f, 19.2101f)
+                curveTo(6.0626f, 19.3099f, 6.0446f, 19.4162f, 6.0476f, 19.523f)
+                curveTo(6.0506f, 19.6297f, 6.0746f, 19.7349f, 6.1183f, 19.8323f)
+                curveTo(6.1619f, 19.9298f, 6.2243f, 20.0177f, 6.3019f, 20.0911f)
+                curveTo(7.4592f, 21.1832f, 8.8661f, 21.9754f, 10.4f, 22.3987f)
+                curveTo(11.9339f, 22.822f, 13.548f, 22.8634f, 15.1015f, 22.5194f)
+                curveTo(16.6551f, 22.1754f, 18.1008f, 21.4564f, 19.3126f, 20.4252f)
+                curveTo(20.5244f, 19.3939f, 21.4654f, 18.0818f, 22.0534f, 16.6032f)
+                curveTo(22.6414f, 15.1247f, 22.8587f, 13.5247f, 22.6862f, 11.9429f)
+                curveTo(22.5137f, 10.3611f, 21.9566f, 8.8456f, 21.0637f, 7.5286f)
+                curveTo(20.1708f, 6.2115f, 18.9691f, 5.1331f, 17.5635f, 4.3873f)
+                curveTo(16.1579f, 3.6415f, 14.5912f, 3.251f, 13.0f, 3.25f)
+                close()
+            }
+        }
+        .build()
+        return requireNotNull(_doneMenu)
+    }
+
+private var _doneMenu: ImageVector? = null

--- a/app/src/main/java/com/soopeach/dowith/ui/icons/menu/PersonalTodoMenu.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/icons/menu/PersonalTodoMenu.kt
@@ -1,0 +1,65 @@
+package com.soopeach.dowith.ui.icons.menu
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val PersonalTodoMenu: ImageVector
+    get() {
+        if (_personalTodoMenu != null) {
+            return requireNotNull(_personalTodoMenu)
+        }
+        _personalTodoMenu = Builder(name = "PersonalTodoMenu", defaultWidth = 26.0.dp, defaultHeight
+                = 26.0.dp, viewportWidth = 26.0f, viewportHeight = 26.0f).apply {
+            path(fill = SolidColor(Color(0xFFB7B7B7)), stroke = null, strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                    pathFillType = NonZero) {
+                moveTo(21.125f, 3.25f)
+                horizontalLineTo(4.875f)
+                curveTo(4.444f, 3.25f, 4.0307f, 3.4212f, 3.726f, 3.726f)
+                curveTo(3.4212f, 4.0307f, 3.25f, 4.444f, 3.25f, 4.875f)
+                verticalLineTo(21.125f)
+                curveTo(3.25f, 21.556f, 3.4212f, 21.9693f, 3.726f, 22.274f)
+                curveTo(4.0307f, 22.5788f, 4.444f, 22.75f, 4.875f, 22.75f)
+                horizontalLineTo(21.125f)
+                curveTo(21.556f, 22.75f, 21.9693f, 22.5788f, 22.274f, 22.274f)
+                curveTo(22.5788f, 21.9693f, 22.75f, 21.556f, 22.75f, 21.125f)
+                verticalLineTo(4.875f)
+                curveTo(22.75f, 4.444f, 22.5788f, 4.0307f, 22.274f, 3.726f)
+                curveTo(21.9693f, 3.4212f, 21.556f, 3.25f, 21.125f, 3.25f)
+                close()
+                moveTo(17.6373f, 11.1373f)
+                lineTo(11.9498f, 16.8248f)
+                curveTo(11.8744f, 16.9004f, 11.7848f, 16.9603f, 11.6861f, 17.0012f)
+                curveTo(11.5875f, 17.0421f, 11.4818f, 17.0631f, 11.375f, 17.0631f)
+                curveTo(11.2682f, 17.0631f, 11.1625f, 17.0421f, 11.0639f, 17.0012f)
+                curveTo(10.9652f, 16.9603f, 10.8756f, 16.9004f, 10.8002f, 16.8248f)
+                lineTo(8.3627f, 14.3873f)
+                curveTo(8.2102f, 14.2349f, 8.1245f, 14.0281f, 8.1245f, 13.8125f)
+                curveTo(8.1245f, 13.5969f, 8.2102f, 13.3901f, 8.3627f, 13.2377f)
+                curveTo(8.5151f, 13.0852f, 8.7219f, 12.9995f, 8.9375f, 12.9995f)
+                curveTo(9.1531f, 12.9995f, 9.3599f, 13.0852f, 9.5123f, 13.2377f)
+                lineTo(11.375f, 15.1013f)
+                lineTo(16.4877f, 9.9877f)
+                curveTo(16.5631f, 9.9122f, 16.6528f, 9.8523f, 16.7514f, 9.8114f)
+                curveTo(16.85f, 9.7706f, 16.9557f, 9.7495f, 17.0625f, 9.7495f)
+                curveTo(17.1693f, 9.7495f, 17.275f, 9.7706f, 17.3736f, 9.8114f)
+                curveTo(17.4722f, 9.8523f, 17.5619f, 9.9122f, 17.6373f, 9.9877f)
+                curveTo(17.7128f, 10.0631f, 17.7727f, 10.1528f, 17.8136f, 10.2514f)
+                curveTo(17.8544f, 10.35f, 17.8755f, 10.4557f, 17.8755f, 10.5625f)
+                curveTo(17.8755f, 10.6693f, 17.8544f, 10.775f, 17.8136f, 10.8736f)
+                curveTo(17.7727f, 10.9722f, 17.7128f, 11.0619f, 17.6373f, 11.1373f)
+                close()
+            }
+        }
+        .build()
+        return requireNotNull(_personalTodoMenu)
+    }
+
+private var _personalTodoMenu: ImageVector? = null

--- a/app/src/main/java/com/soopeach/dowith/ui/icons/menu/TeamTodoMenu.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/icons/menu/TeamTodoMenu.kt
@@ -1,0 +1,87 @@
+package com.soopeach.dowith.ui.icons.menu
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val TeamTodoMenu: ImageVector
+    get() {
+        if (_teamTodoMenu != null) {
+            return requireNotNull(_teamTodoMenu)
+        }
+        _teamTodoMenu = Builder(name = "TeamTodoMenu", defaultWidth = 26.0.dp, defaultHeight =
+                26.0.dp, viewportWidth = 26.0f, viewportHeight = 26.0f).apply {
+            path(fill = SolidColor(Color(0xFFB7B7B7)), stroke = null, strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                    pathFillType = NonZero) {
+                moveTo(24.1429f, 3.7143f)
+                horizontalLineTo(1.8571f)
+                curveTo(1.3646f, 3.7143f, 0.8922f, 3.91f, 0.5439f, 4.2582f)
+                curveTo(0.1957f, 4.6065f, 0.0f, 5.0789f, 0.0f, 5.5714f)
+                verticalLineTo(20.4286f)
+                curveTo(0.0f, 20.9211f, 0.1957f, 21.3935f, 0.5439f, 21.7418f)
+                curveTo(0.8922f, 22.0901f, 1.3646f, 22.2857f, 1.8571f, 22.2857f)
+                horizontalLineTo(24.1429f)
+                curveTo(24.6354f, 22.2857f, 25.1078f, 22.0901f, 25.4561f, 21.7418f)
+                curveTo(25.8043f, 21.3935f, 26.0f, 20.9211f, 26.0f, 20.4286f)
+                verticalLineTo(5.5714f)
+                curveTo(26.0f, 5.0789f, 25.8043f, 4.6065f, 25.4561f, 4.2582f)
+                curveTo(25.1078f, 3.91f, 24.6354f, 3.7143f, 24.1429f, 3.7143f)
+                close()
+                moveTo(7.4286f, 16.7143f)
+                curveTo(7.3066f, 16.7144f, 7.1858f, 16.6905f, 7.0731f, 16.6439f)
+                curveTo(6.9603f, 16.5972f, 6.8579f, 16.5289f, 6.7716f, 16.4427f)
+                lineTo(3.9859f, 13.657f)
+                curveTo(3.8117f, 13.4827f, 3.7138f, 13.2464f, 3.7138f, 13.0f)
+                curveTo(3.7138f, 12.7536f, 3.8117f, 12.5173f, 3.9859f, 12.343f)
+                curveTo(4.1601f, 12.1688f, 4.3965f, 12.0709f, 4.6429f, 12.0709f)
+                curveTo(4.8893f, 12.0709f, 5.1256f, 12.1688f, 5.2998f, 12.343f)
+                lineTo(7.4286f, 14.473f)
+                lineTo(13.2716f, 8.6288f)
+                curveTo(13.3579f, 8.5425f, 13.4603f, 8.474f, 13.573f, 8.4274f)
+                curveTo(13.6857f, 8.3807f, 13.8066f, 8.3566f, 13.9286f, 8.3566f)
+                curveTo(14.0506f, 8.3566f, 14.1714f, 8.3807f, 14.2841f, 8.4274f)
+                curveTo(14.3968f, 8.474f, 14.4993f, 8.5425f, 14.5855f, 8.6288f)
+                curveTo(14.6718f, 8.715f, 14.7402f, 8.8174f, 14.7869f, 8.9302f)
+                curveTo(14.8336f, 9.0429f, 14.8577f, 9.1637f, 14.8577f, 9.2857f)
+                curveTo(14.8577f, 9.4077f, 14.8336f, 9.5286f, 14.7869f, 9.6413f)
+                curveTo(14.7402f, 9.754f, 14.6718f, 9.8564f, 14.5855f, 9.9427f)
+                lineTo(8.0855f, 16.4427f)
+                curveTo(7.9992f, 16.5289f, 7.8968f, 16.5972f, 7.7841f, 16.6439f)
+                curveTo(7.6714f, 16.6905f, 7.5505f, 16.7144f, 7.4286f, 16.7143f)
+                close()
+                moveTo(22.9427f, 9.9427f)
+                lineTo(16.4427f, 16.4427f)
+                curveTo(16.3564f, 16.529f, 16.254f, 16.5975f, 16.1413f, 16.6442f)
+                curveTo(16.0286f, 16.691f, 15.9077f, 16.715f, 15.7857f, 16.715f)
+                curveTo(15.6637f, 16.715f, 15.5429f, 16.691f, 15.4301f, 16.6442f)
+                curveTo(15.3174f, 16.5975f, 15.215f, 16.529f, 15.1287f, 16.4427f)
+                lineTo(13.2716f, 14.5855f)
+                curveTo(13.0974f, 14.4113f, 12.9995f, 14.175f, 12.9995f, 13.9286f)
+                curveTo(12.9995f, 13.6822f, 13.0974f, 13.4459f, 13.2716f, 13.2716f)
+                curveTo(13.4458f, 13.0974f, 13.6822f, 12.9995f, 13.9286f, 12.9995f)
+                curveTo(14.175f, 12.9995f, 14.4113f, 13.0974f, 14.5855f, 13.2716f)
+                lineTo(15.7857f, 14.473f)
+                lineTo(21.6287f, 8.6288f)
+                curveTo(21.715f, 8.5425f, 21.8174f, 8.474f, 21.9302f, 8.4274f)
+                curveTo(22.0429f, 8.3807f, 22.1637f, 8.3566f, 22.2857f, 8.3566f)
+                curveTo(22.4077f, 8.3566f, 22.5285f, 8.3807f, 22.6413f, 8.4274f)
+                curveTo(22.754f, 8.474f, 22.8564f, 8.5425f, 22.9427f, 8.6288f)
+                curveTo(23.029f, 8.715f, 23.0974f, 8.8174f, 23.1441f, 8.9302f)
+                curveTo(23.1908f, 9.0429f, 23.2148f, 9.1637f, 23.2148f, 9.2857f)
+                curveTo(23.2148f, 9.4077f, 23.1908f, 9.5286f, 23.1441f, 9.6413f)
+                curveTo(23.0974f, 9.754f, 23.029f, 9.8564f, 22.9427f, 9.9427f)
+                close()
+            }
+        }
+        .build()
+        return requireNotNull(_teamTodoMenu)
+    }
+
+private var _teamTodoMenu: ImageVector? = null

--- a/app/src/main/java/com/soopeach/dowith/ui/icons/menu/__BottomNavigationIconPack.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/icons/menu/__BottomNavigationIconPack.kt
@@ -1,0 +1,17 @@
+package com.soopeach.dowith.ui.icons.menu
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import kotlin.collections.List as ____KtList
+
+object BottomNavigationIconPack
+
+private var __AllIcons: ____KtList<ImageVector>? = null
+
+val BottomNavigationIconPack.AllIcons: ____KtList<ImageVector>
+  get() {
+    if (__AllIcons != null) {
+      return __AllIcons!!
+    }
+    __AllIcons = listOf(DoneMenu, PersonalTodoMenu, TeamTodoMenu)
+    return __AllIcons!!
+  }

--- a/app/src/main/java/com/soopeach/dowith/ui/screen/Screen.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/screen/Screen.kt
@@ -1,13 +1,12 @@
 package com.soopeach.dowith.ui.screen
 
 import androidx.annotation.StringRes
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Done
-import androidx.compose.material.icons.rounded.Groups
-import androidx.compose.material.icons.rounded.Person
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NamedNavArgument
 import com.soopeach.dowith.R
+import com.soopeach.dowith.ui.icons.menu.DoneMenu
+import com.soopeach.dowith.ui.icons.menu.PersonalTodoMenu
+import com.soopeach.dowith.ui.icons.menu.TeamTodoMenu
 
 sealed class Screen(
     val route: String,
@@ -16,9 +15,9 @@ sealed class Screen(
     val arguments: List<NamedNavArgument> = emptyList()
 ) {
 
-    object PersonalTodo : Screen("personalTodo", R.string.personal_todo, Icons.Rounded.Person)
-    object TeamTodo : Screen("teamTodo", R.string.team_todo, Icons.Rounded.Groups)
-    object Done : Screen("done", R.string.done, Icons.Rounded.Done)
+    object PersonalTodo : Screen("personalTodo", R.string.personal_todo, PersonalTodoMenu)
+    object TeamTodo : Screen("teamTodo", R.string.team_todo, TeamTodoMenu)
+    object Done : Screen("done", R.string.done, DoneMenu)
 
     companion object {
         val bottomNavigationItems = listOf(PersonalTodo, TeamTodo, Done)

--- a/app/src/main/java/com/soopeach/dowith/ui/theme/Theme.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/theme/Theme.kt
@@ -1,17 +1,13 @@
 package com.soopeach.dowith.ui.theme
 
 import android.app.Activity
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
@@ -41,14 +37,15 @@ private val LightColorScheme = lightColorScheme(
 fun DoWithTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
+//    dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
+
+//        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+//            val context = LocalContext.current
+//            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+//        }
 
         darkTheme -> DarkColorScheme
         else -> LightColorScheme

--- a/app/src/main/java/com/soopeach/dowith/ui/theme/Theme.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/theme/Theme.kt
@@ -16,14 +16,14 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
+    primary = DoWithColors.orange1000,
+    secondary = DoWithColors.gray500,
     tertiary = Pink80
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
+    primary = DoWithColors.orange1000,
+    secondary = DoWithColors.gray500,
     tertiary = Pink40
 
     /* Other default colors to override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">DoWith</string>
-    <string name="personal_todo">개인</string>
-    <string name="team_todo">팀</string>
-    <string name="done">완료</string>
+    <string name="personal_todo">개인 투두</string>
+    <string name="team_todo">팀 투두</string>
+    <string name="done">이전 기록</string>
 </resources>


### PR DESCRIPTION
## 개요
- Bottom Navigation 디자인 스팩에 맞춰 변경
  - 색상
  - 아이콘
  - 라벨
- Theme Color 일부 세팅
 - Primary, Secondary Color 조절
 - 다이나믹 컬러 비활성화  

## 동작 모습
<img width="268" alt="Screenshot 2023-05-30 at 12 45 50 AM" src="https://github.com/Do-It-Do-It-Chu/Dowith-Android/assets/90144041/10c3a013-c568-4041-a1d4-7dac63b96936">
