### PR TITLE
개인 투두 더보기 페이지 구현

### DIFF
--- a/app/src/main/java/com/soopeach/dowith/ui/AppScreen.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/AppScreen.kt
@@ -21,6 +21,7 @@ import com.soopeach.dowith.ui.screen.done.DoneScreen
 import com.soopeach.dowith.ui.screen.Screen
 import com.soopeach.dowith.ui.screen.Screen.Companion.bottomNavigationItems
 import com.soopeach.dowith.ui.screen.personal.PersonalTodoMainScreen
+import com.soopeach.dowith.ui.screen.personal.PersonalTodoMoreScreen
 import com.soopeach.dowith.ui.screen.team.TeamTodoMainScreen
 import com.soopeach.dowith.ui.theme.DoWithColors
 import com.soopeach.dowith.ui.theme.DoWithTypography
@@ -83,6 +84,10 @@ fun AppScreen() {
             }
             composable(Screen.Done.route) {
                 DoneScreen(navController)
+            }
+
+            composable(Screen.PersonalTodoMore.route) {
+                PersonalTodoMoreScreen(navController)
             }
 
         }

--- a/app/src/main/java/com/soopeach/dowith/ui/AppScreen.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/AppScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -32,6 +34,7 @@ fun AppScreen() {
     val navController = rememberNavController()
 
     Scaffold(
+        modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection()),
         bottomBar = {
 
             val navBackStackEntry by navController.currentBackStackEntryAsState()

--- a/app/src/main/java/com/soopeach/dowith/ui/component/DoWithTopBar.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/component/DoWithTopBar.kt
@@ -44,41 +44,42 @@ fun DoWithTopBar(
         ) {
 
             navigationIcon?.invoke() ?: run {
+
                 Image(
                     modifier = Modifier.size(60.dp, 23.dp),
                     contentScale = ContentScale.Crop,
                     imageVector = Logo,
                     contentDescription = "두윗 로고"
                 )
-            }
 
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
 
-                Icon(
-                    modifier = Modifier
-                        .size(24.dp)
-                        .clip(shape = CircleShape)
-                        .clickable {
-                            onNotificationClicked()
-                        },
-                    imageVector = NotificationIcon,
-                    contentDescription = "알림 아이콘",
-                    tint = DoWithColors.gray500
-                )
+                    Icon(
+                        modifier = Modifier
+                            .size(24.dp)
+                            .clip(shape = CircleShape)
+                            .clickable {
+                                onNotificationClicked()
+                            },
+                        imageVector = NotificationIcon,
+                        contentDescription = "알림 아이콘",
+                        tint = DoWithColors.gray500
+                    )
 
-                Icon(
-                    modifier = Modifier
-                        .size(24.dp)
-                        .clip(shape = CircleShape)
-                        .clickable {
-                            onMyPageClicked()
-                        },
-                    imageVector = MyPageIcon,
-                    contentDescription = "마이 페이지 아이콘",
-                    tint = DoWithColors.gray500
-                )
+                    Icon(
+                        modifier = Modifier
+                            .size(24.dp)
+                            .clip(shape = CircleShape)
+                            .clickable {
+                                onMyPageClicked()
+                            },
+                        imageVector = MyPageIcon,
+                        contentDescription = "마이 페이지 아이콘",
+                        tint = DoWithColors.gray500
+                    )
+                }
             }
 
         }

--- a/app/src/main/java/com/soopeach/dowith/ui/component/NicknameTodoListExplainText.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/component/NicknameTodoListExplainText.kt
@@ -1,0 +1,39 @@
+package com.soopeach.dowith.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+import com.soopeach.dowith.ui.theme.DoWithColors
+import com.soopeach.dowith.ui.theme.DoWithTypography
+
+@Composable
+fun NicknameTodoListExplainText(
+    isPersonal: Boolean = true,
+    nickname: String
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = nickname,
+                style = DoWithTypography.Title2.copy(DoWithColors.orange1000)
+            )
+            Text(
+                text = "님의",
+                style = DoWithTypography.Body1.copy(DoWithColors.gray800)
+            )
+        }
+        Text(
+            text = if (isPersonal) "개인 투두리스트!" else "팀 투두리스트!",
+            style = DoWithTypography.Title1.copy(DoWithColors.gray800)
+        )
+    }
+}

--- a/app/src/main/java/com/soopeach/dowith/ui/component/TodoItemComposable.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/component/TodoItemComposable.kt
@@ -52,7 +52,7 @@ fun TodoItemComposable(
                     .clickable {
                         onTodoIconClicked()
                     },
-                imageVector = if (todoItem.isChecked) TodoIcon else DoneIcon,
+                imageVector = if (todoItem.isChecked) DoneIcon else TodoIcon,
                 contentDescription = "",
                 tint = if (todoItem.isChecked) DoWithColors.orange1000 else DoWithColors.gray400
             )

--- a/app/src/main/java/com/soopeach/dowith/ui/component/TodoItemComposable.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/component/TodoItemComposable.kt
@@ -59,7 +59,7 @@ fun TodoItemComposable(
 
             Spacer(modifier = Modifier.width(8.dp))
 
-            var textFieldValue by remember {
+            var textFieldValue by remember(todoItem.content) {
                 mutableStateOf(
                     TextFieldValue(
                         text = todoItem.content,

--- a/app/src/main/java/com/soopeach/dowith/ui/component/TodoItemComposable.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/component/TodoItemComposable.kt
@@ -35,7 +35,7 @@ fun TodoItemComposable(
     isMoreIconVisible: Boolean = false,
     onTodoIconClicked: () -> Unit = {},
     onMoreIconClicked: () -> Unit = {},
-    onKeyboardActionClicked: () -> Unit = {},
+    onKeyboardActionClicked: (String) -> Unit = {},
     onTextChanged: (String) -> Unit = {},
 ) {
 
@@ -79,7 +79,7 @@ fun TodoItemComposable(
                 singleLine = true,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                 keyboardActions = KeyboardActions {
-                    onKeyboardActionClicked()
+                    onKeyboardActionClicked(textFieldValue.text)
                 }
             )
         }

--- a/app/src/main/java/com/soopeach/dowith/ui/component/TodoItemComposable.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/component/TodoItemComposable.kt
@@ -5,11 +5,20 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Icon
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import com.soopeach.domain.model.TodoItem
 import com.soopeach.dowith.ui.icons.DoneIcon
@@ -22,9 +31,12 @@ import com.soopeach.dowith.ui.theme.DoWithTypography
 fun TodoItemComposable(
     modifier: Modifier = Modifier,
     todoItem: TodoItem,
+    isEditable: Boolean = false,
     isMoreIconVisible: Boolean = false,
     onTodoIconClicked: () -> Unit = {},
-    onMoreIconClicked: () -> Unit = {}
+    onMoreIconClicked: () -> Unit = {},
+    onKeyboardActionClicked: () -> Unit = {},
+    onTextChanged: (String) -> Unit = {},
 ) {
 
     Row(
@@ -47,9 +59,28 @@ fun TodoItemComposable(
 
             Spacer(modifier = Modifier.width(8.dp))
 
-            Text(
-                text = todoItem.content,
-                style = DoWithTypography.Body2.copy(DoWithColors.gray700)
+            var textFieldValue by remember {
+                mutableStateOf(
+                    TextFieldValue(
+                        text = todoItem.content,
+                        selection = TextRange(todoItem.content.length)
+                    )
+                )
+            }
+
+            BasicTextField(
+                value = textFieldValue,
+                onValueChange = {
+                    textFieldValue = it
+                    onTextChanged(textFieldValue.text)
+                },
+                textStyle = DoWithTypography.Body2.copy(DoWithColors.gray700),
+                enabled = isEditable,
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions {
+                    onKeyboardActionClicked()
+                }
             )
         }
 

--- a/app/src/main/java/com/soopeach/dowith/ui/component/WillBeRegisteredTodo.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/component/WillBeRegisteredTodo.kt
@@ -1,0 +1,30 @@
+package com.soopeach.dowith.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import com.soopeach.dowith.ui.icons.TodoIcon
+import com.soopeach.dowith.ui.theme.DoWithColors
+import com.soopeach.dowith.ui.theme.DoWithTypography
+
+@Composable
+fun WillBeRegisteredTodo(
+    content: String
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(
+            TodoIcon,
+            contentDescription = "Todo 아이콘", tint = DoWithColors.gray400
+        )
+
+        Text(
+            text = content,
+            style = DoWithTypography.Body2.copy(DoWithColors.gray700),
+        )
+    }
+}

--- a/app/src/main/java/com/soopeach/dowith/ui/component/bottomsheet/TodoContainerModalBottomSheetLayout.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/component/bottomsheet/TodoContainerModalBottomSheetLayout.kt
@@ -1,0 +1,135 @@
+package com.soopeach.dowith.ui.component.bottomsheet
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Icon
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.Text
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.soopeach.dowith.ui.icons.EraserIcon
+import com.soopeach.dowith.ui.icons.TrashCanIcon
+import com.soopeach.dowith.ui.theme.DoWithColors
+import com.soopeach.dowith.ui.theme.DoWithTypography
+import kotlinx.coroutines.CoroutineScope
+
+sealed interface TodoContainerModalBottomSheetType {
+    object Write : TodoContainerModalBottomSheetType
+    object More : TodoContainerModalBottomSheetType
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun TodoContainerModalBottomSheetLayout(
+    bottomSheetType: TodoContainerModalBottomSheetType = TodoContainerModalBottomSheetType.More,
+    coroutineScope: CoroutineScope = rememberCoroutineScope(),
+    modalSheetState: ModalBottomSheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden,
+        confirmValueChange = { it != ModalBottomSheetValue.HalfExpanded },
+        skipHalfExpanded = false
+    ),
+    onModifyButtonClicked: () -> Unit = {},
+    onDeleteButtonClicked: () -> Unit = {},
+    content: @Composable () -> Unit = {
+
+    },
+) {
+    ModalBottomSheetLayout(
+        sheetState = modalSheetState,
+        sheetShape = RoundedCornerShape(12.dp, 12.dp, 0.dp, 0.dp),
+        sheetContent = {
+
+            when (bottomSheetType) {
+                TodoContainerModalBottomSheetType.Write -> {
+
+                }
+
+                TodoContainerModalBottomSheetType.More -> {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 20.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+
+                        Spacer(modifier = Modifier.height(10.dp))
+
+                        Box(
+                            modifier = Modifier
+                                .size(40.dp, 4.dp)
+                                .clip(RoundedCornerShape(11.dp))
+                                .background(color = DoWithColors.gray400)
+                        )
+
+                        Spacer(modifier = Modifier.height(34.dp))
+
+                        TextButtonWithLeftIcon(
+                            text = "수정하기",
+                            onButtonClicked = { onModifyButtonClicked() }) {
+                            Icon(
+                                EraserIcon, contentDescription = "수정하기 아이콘",
+                                tint = DoWithColors.gray700
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.height(30.dp))
+
+                        TextButtonWithLeftIcon(
+                            text = "삭제하기",
+                            onButtonClicked = { onDeleteButtonClicked() }) {
+                            Icon(
+                                TrashCanIcon, contentDescription = "삭제하기 아이콘",
+                                tint = DoWithColors.gray700
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.height(52.dp))
+
+                    }
+                }
+            }
+        }
+    ) {
+        content()
+    }
+}
+
+@Composable
+fun TextButtonWithLeftIcon(
+    text: String,
+    onButtonClicked: () -> Unit,
+    icon: @Composable () -> Unit
+) {
+    Row(
+        modifier = Modifier.clickable {
+            onButtonClicked()
+        },
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+
+        icon()
+        Text(
+            text = text,
+            style = DoWithTypography.Body2.copy(DoWithColors.gray700)
+        )
+    }
+}

--- a/app/src/main/java/com/soopeach/dowith/ui/component/bottomsheet/TodoContainerModalBottomSheetLayout.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/component/bottomsheet/TodoContainerModalBottomSheetLayout.kt
@@ -7,29 +7,45 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import com.soopeach.domain.utils.empty
+import com.soopeach.dowith.ui.component.WillBeRegisteredTodo
 import com.soopeach.dowith.ui.icons.EraserIcon
 import com.soopeach.dowith.ui.icons.TrashCanIcon
 import com.soopeach.dowith.ui.theme.DoWithColors
 import com.soopeach.dowith.ui.theme.DoWithTypography
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 sealed interface TodoContainerModalBottomSheetType {
     object Write : TodoContainerModalBottomSheetType
@@ -48,10 +64,14 @@ fun TodoContainerModalBottomSheetLayout(
     ),
     onModifyButtonClicked: () -> Unit = {},
     onDeleteButtonClicked: () -> Unit = {},
+    onCompleteButtonClicked: (List<String>) -> Unit = {},
     content: @Composable () -> Unit = {
 
     },
 ) {
+
+    val focusManager = LocalFocusManager.current
+
     ModalBottomSheetLayout(
         sheetState = modalSheetState,
         sheetShape = RoundedCornerShape(12.dp, 12.dp, 0.dp, 0.dp),
@@ -60,6 +80,110 @@ fun TodoContainerModalBottomSheetLayout(
             when (bottomSheetType) {
                 TodoContainerModalBottomSheetType.Write -> {
 
+                    var todoContentList by remember {
+                        mutableStateOf(listOf<String>())
+                    }
+
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = 20.dp),
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 20.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+
+                            Icon(
+                                modifier = Modifier.clickable {
+                                    todoContentList = emptyList()
+                                    focusManager.clearFocus()
+                                    coroutineScope.launch {
+                                        modalSheetState.hide()
+                                    }
+                                },
+                                imageVector = Icons.Filled.Close, contentDescription = "닫기 버튼",
+                                tint = DoWithColors.gray700
+                            )
+
+                            Text(
+                                text = "작성하기",
+                                style = DoWithTypography.Title3.copy(color = DoWithColors.gray700),
+                            )
+
+                            Text(
+                                modifier = Modifier.clickable {
+                                    onCompleteButtonClicked(todoContentList)
+                                    todoContentList = emptyList()
+                                    focusManager.clearFocus()
+                                    coroutineScope.launch {
+                                        modalSheetState.hide()
+                                    }
+                                },
+                                text = "완료",
+                                style = DoWithTypography.Body2.copy(color = DoWithColors.orange1000),
+                            )
+
+                        }
+
+                        Spacer(modifier = Modifier.height(10.dp))
+
+                        Box(
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(12.dp))
+                                .height(44.dp)
+                                .background(color = DoWithColors.gray100)
+                        ) {
+
+                            var textValue by remember {
+                                mutableStateOf(String.empty)
+                            }
+
+                            BasicTextField(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 20.dp, vertical = 11.dp),
+                                value = textValue,
+                                textStyle = DoWithTypography.Body3.copy(color = DoWithColors.gray700),
+                                singleLine = true,
+                                onValueChange = {
+                                    textValue = it
+                                },
+                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                                keyboardActions = KeyboardActions {
+                                    if (textValue.isNotEmpty()) {
+                                        todoContentList = todoContentList + textValue
+                                        textValue = String.empty
+                                    }
+                                },
+                                decorationBox = { innerTextField ->
+                                    if (textValue.isEmpty()) {
+                                        Text(
+                                            "오늘 할 일을 적어주세요",
+                                            style = DoWithTypography.Body3.copy(color = DoWithColors.gray400)
+                                        )
+                                    }
+                                    innerTextField()
+                                }
+                            )
+                        }
+
+                        LazyColumn(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(20.dp),
+                            verticalArrangement = Arrangement.spacedBy(16.dp),
+                        ) {
+                            todoContentList.forEach {
+                                item {
+                                    WillBeRegisteredTodo(it)
+                                }
+                            }
+                        }
+
+                    }
                 }
 
                 TodoContainerModalBottomSheetType.More -> {

--- a/app/src/main/java/com/soopeach/dowith/ui/icons/DoneIcon.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/icons/DoneIcon.kt
@@ -15,16 +15,26 @@ val DoneIcon: ImageVector
         if (_doneIcon != null) {
             return requireNotNull(_doneIcon)
         }
-        _doneIcon = Builder(name = "DoneIcon", defaultWidth = 24.0.dp, defaultHeight = 24.0.dp,
-                viewportWidth = 24.0f, viewportHeight = 24.0f).apply {
-            path(fill = SolidColor(Color(0xFFB7B7B7)), stroke = null, strokeLineWidth = 0.0f,
-                    strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
-                    pathFillType = NonZero) {
-                moveTo(16.2806f, 9.2194f)
-                curveTo(16.3504f, 9.289f, 16.4057f, 9.3717f, 16.4434f, 9.4628f)
-                curveTo(16.4812f, 9.5538f, 16.5006f, 9.6514f, 16.5006f, 9.75f)
-                curveTo(16.5006f, 9.8486f, 16.4812f, 9.9462f, 16.4434f, 10.0372f)
-                curveTo(16.4057f, 10.1283f, 16.3504f, 10.211f, 16.2806f, 10.2806f)
+        _doneIcon = Builder(name = "TodoIcon", defaultWidth = 24.0.dp, defaultHeight = 24.0.dp,
+            viewportWidth = 24.0f, viewportHeight = 24.0f).apply {
+            path(fill = SolidColor(Color(0xFFFF7F00)), stroke = null, strokeLineWidth = 0.0f,
+                strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                pathFillType = NonZero) {
+                moveTo(19.5f, 3.0f)
+                horizontalLineTo(4.5f)
+                curveTo(4.1022f, 3.0f, 3.7206f, 3.158f, 3.4393f, 3.4393f)
+                curveTo(3.158f, 3.7206f, 3.0f, 4.1022f, 3.0f, 4.5f)
+                verticalLineTo(19.5f)
+                curveTo(3.0f, 19.8978f, 3.158f, 20.2794f, 3.4393f, 20.5607f)
+                curveTo(3.7206f, 20.842f, 4.1022f, 21.0f, 4.5f, 21.0f)
+                horizontalLineTo(19.5f)
+                curveTo(19.8978f, 21.0f, 20.2794f, 20.842f, 20.5607f, 20.5607f)
+                curveTo(20.842f, 20.2794f, 21.0f, 19.8978f, 21.0f, 19.5f)
+                verticalLineTo(4.5f)
+                curveTo(21.0f, 4.1022f, 20.842f, 3.7206f, 20.5607f, 3.4393f)
+                curveTo(20.2794f, 3.158f, 19.8978f, 3.0f, 19.5f, 3.0f)
+                close()
+                moveTo(16.2806f, 10.2806f)
                 lineTo(11.0306f, 15.5306f)
                 curveTo(10.961f, 15.6004f, 10.8783f, 15.6557f, 10.7872f, 15.6934f)
                 curveTo(10.6962f, 15.7312f, 10.5986f, 15.7506f, 10.5f, 15.7506f)
@@ -37,30 +47,14 @@ val DoneIcon: ImageVector
                 curveTo(8.449f, 11.9996f, 8.6399f, 12.0786f, 8.7806f, 12.2194f)
                 lineTo(10.5f, 13.9397f)
                 lineTo(15.2194f, 9.2194f)
-                curveTo(15.289f, 9.1496f, 15.3717f, 9.0943f, 15.4628f, 9.0566f)
-                curveTo(15.5538f, 9.0188f, 15.6514f, 8.9994f, 15.75f, 8.9994f)
-                curveTo(15.8486f, 8.9994f, 15.9462f, 9.0188f, 16.0372f, 9.0566f)
-                curveTo(16.1283f, 9.0943f, 16.211f, 9.1496f, 16.2806f, 9.2194f)
-                close()
-                moveTo(21.0f, 4.5f)
-                verticalLineTo(19.5f)
-                curveTo(21.0f, 19.8978f, 20.842f, 20.2794f, 20.5607f, 20.5607f)
-                curveTo(20.2794f, 20.842f, 19.8978f, 21.0f, 19.5f, 21.0f)
-                horizontalLineTo(4.5f)
-                curveTo(4.1022f, 21.0f, 3.7206f, 20.842f, 3.4393f, 20.5607f)
-                curveTo(3.158f, 20.2794f, 3.0f, 19.8978f, 3.0f, 19.5f)
-                verticalLineTo(4.5f)
-                curveTo(3.0f, 4.1022f, 3.158f, 3.7206f, 3.4393f, 3.4393f)
-                curveTo(3.7206f, 3.158f, 4.1022f, 3.0f, 4.5f, 3.0f)
-                horizontalLineTo(19.5f)
-                curveTo(19.8978f, 3.0f, 20.2794f, 3.158f, 20.5607f, 3.4393f)
-                curveTo(20.842f, 3.7206f, 21.0f, 4.1022f, 21.0f, 4.5f)
-                close()
-                moveTo(19.5f, 19.5f)
-                verticalLineTo(4.5f)
-                horizontalLineTo(4.5f)
-                verticalLineTo(19.5f)
-                horizontalLineTo(19.5f)
+                curveTo(15.2891f, 9.1497f, 15.3718f, 9.0944f, 15.4628f, 9.0567f)
+                curveTo(15.5539f, 9.019f, 15.6515f, 8.9996f, 15.75f, 8.9996f)
+                curveTo(15.8485f, 8.9996f, 15.9461f, 9.019f, 16.0372f, 9.0567f)
+                curveTo(16.1282f, 9.0944f, 16.2109f, 9.1497f, 16.2806f, 9.2194f)
+                curveTo(16.3503f, 9.2891f, 16.4056f, 9.3718f, 16.4433f, 9.4628f)
+                curveTo(16.481f, 9.5539f, 16.5004f, 9.6515f, 16.5004f, 9.75f)
+                curveTo(16.5004f, 9.8485f, 16.481f, 9.9461f, 16.4433f, 10.0372f)
+                curveTo(16.4056f, 10.1282f, 16.3503f, 10.2109f, 16.2806f, 10.2806f)
                 close()
             }
         }

--- a/app/src/main/java/com/soopeach/dowith/ui/icons/EraserIcon.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/icons/EraserIcon.kt
@@ -1,0 +1,66 @@
+package com.soopeach.dowith.ui.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val EraserIcon: ImageVector
+    get() {
+        if (_eraserIcon != null) {
+            return requireNotNull(_eraserIcon)
+        }
+        _eraserIcon = Builder(
+            name = "Eraser", defaultWidth = 20.0.dp, defaultHeight = 20.0.dp,
+            viewportWidth = 20.0f, viewportHeight = 20.0f
+        ).apply {
+            path(
+                fill = SolidColor(Color(0xFF555555)), stroke = null, strokeLineWidth = 0.0f,
+                strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(17.5782f, 6.2813f)
+                lineTo(14.3438f, 3.0469f)
+                curveTo(13.9922f, 2.6953f, 13.5153f, 2.4977f, 13.018f, 2.4977f)
+                curveTo(12.5208f, 2.4977f, 12.0439f, 2.6953f, 11.6922f, 3.0469f)
+                lineTo(2.4219f, 12.3172f)
+                curveTo(2.0703f, 12.6688f, 1.8728f, 13.1457f, 1.8728f, 13.643f)
+                curveTo(1.8728f, 14.1402f, 2.0703f, 14.6171f, 2.4219f, 14.9687f)
+                lineTo(4.7704f, 17.3172f)
+                curveTo(4.8286f, 17.3754f, 4.8979f, 17.4215f, 4.974f, 17.4529f)
+                curveTo(5.0501f, 17.4843f, 5.1318f, 17.5003f, 5.2141f, 17.5f)
+                horizontalLineTo(16.8751f)
+                curveTo(17.0408f, 17.5f, 17.1998f, 17.4341f, 17.317f, 17.3169f)
+                curveTo(17.4342f, 17.1997f, 17.5001f, 17.0408f, 17.5001f, 16.875f)
+                curveTo(17.5001f, 16.7092f, 17.4342f, 16.5503f, 17.317f, 16.4331f)
+                curveTo(17.1998f, 16.3158f, 17.0408f, 16.25f, 16.8751f, 16.25f)
+                horizontalLineTo(10.2579f)
+                lineTo(17.5782f, 8.9328f)
+                curveTo(17.9298f, 8.5812f, 18.1273f, 8.1043f, 18.1273f, 7.607f)
+                curveTo(18.1273f, 7.1098f, 17.9298f, 6.6329f, 17.5782f, 6.2813f)
+                close()
+                moveTo(16.693f, 8.0469f)
+                lineTo(12.5001f, 12.2414f)
+                lineTo(8.3836f, 8.125f)
+                lineTo(12.5782f, 3.9328f)
+                curveTo(12.6362f, 3.8747f, 12.7052f, 3.8286f, 12.781f, 3.7971f)
+                curveTo(12.8569f, 3.7657f, 12.9382f, 3.7495f, 13.0204f, 3.7495f)
+                curveTo(13.1025f, 3.7495f, 13.1838f, 3.7657f, 13.2597f, 3.7971f)
+                curveTo(13.3356f, 3.8286f, 13.4045f, 3.8747f, 13.4626f, 3.9328f)
+                lineTo(16.6954f, 7.1656f)
+                curveTo(16.8125f, 7.2828f, 16.8783f, 7.4417f, 16.8783f, 7.6074f)
+                curveTo(16.8783f, 7.7731f, 16.8125f, 7.932f, 16.6954f, 8.0492f)
+                lineTo(16.693f, 8.0469f)
+                close()
+            }
+        }
+            .build()
+        return requireNotNull(_eraserIcon)
+    }
+
+private var _eraserIcon: ImageVector? = null

--- a/app/src/main/java/com/soopeach/dowith/ui/icons/PencilIcon.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/icons/PencilIcon.kt
@@ -1,0 +1,76 @@
+package com.soopeach.dowith.ui.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val PencilIcon: ImageVector
+    get() {
+        if (_pencilIcon != null) {
+            return requireNotNull(_pencilIcon)
+        }
+        _pencilIcon = Builder(name = "PencilIcon", defaultWidth = 20.0.dp, defaultHeight = 20.0.dp,
+                viewportWidth = 20.0f, viewportHeight = 20.0f).apply {
+            path(fill = SolidColor(Color(0xFF949494)), stroke = null, strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                    pathFillType = NonZero) {
+                moveTo(17.7594f, 5.7321f)
+                lineTo(14.268f, 2.2415f)
+                curveTo(14.1519f, 2.1254f, 14.0141f, 2.0333f, 13.8624f, 1.9704f)
+                curveTo(13.7107f, 1.9076f, 13.5482f, 1.8752f, 13.384f, 1.8752f)
+                curveTo(13.2198f, 1.8752f, 13.0572f, 1.9076f, 12.9056f, 1.9704f)
+                curveTo(12.7539f, 2.0333f, 12.6161f, 2.1254f, 12.5f, 2.2415f)
+                lineTo(2.8664f, 11.8751f)
+                curveTo(2.7498f, 11.9907f, 2.6574f, 12.1284f, 2.5945f, 12.2801f)
+                curveTo(2.5316f, 12.4318f, 2.4995f, 12.5944f, 2.5f, 12.7586f)
+                verticalLineTo(16.2501f)
+                curveTo(2.5f, 16.5816f, 2.6317f, 16.8995f, 2.8661f, 17.1339f)
+                curveTo(3.1005f, 17.3684f, 3.4185f, 17.5001f, 3.75f, 17.5001f)
+                horizontalLineTo(16.875f)
+                curveTo(17.0408f, 17.5001f, 17.1997f, 17.4342f, 17.3169f, 17.317f)
+                curveTo(17.4342f, 17.1998f, 17.5f, 17.0408f, 17.5f, 16.8751f)
+                curveTo(17.5f, 16.7093f, 17.4342f, 16.5503f, 17.3169f, 16.4331f)
+                curveTo(17.1997f, 16.3159f, 17.0408f, 16.2501f, 16.875f, 16.2501f)
+                horizontalLineTo(9.0094f)
+                lineTo(17.7594f, 7.5001f)
+                curveTo(17.8755f, 7.384f, 17.9676f, 7.2462f, 18.0304f, 7.0945f)
+                curveTo(18.0933f, 6.9428f, 18.1256f, 6.7803f, 18.1256f, 6.6161f)
+                curveTo(18.1256f, 6.4519f, 18.0933f, 6.2893f, 18.0304f, 6.1377f)
+                curveTo(17.9676f, 5.986f, 17.8755f, 5.8482f, 17.7594f, 5.7321f)
+                close()
+                moveTo(10.625f, 5.8836f)
+                lineTo(11.9289f, 7.1876f)
+                lineTo(5.3125f, 13.804f)
+                lineTo(4.0086f, 12.5001f)
+                lineTo(10.625f, 5.8836f)
+                close()
+                moveTo(3.75f, 16.2501f)
+                verticalLineTo(14.0086f)
+                lineTo(5.9914f, 16.2501f)
+                horizontalLineTo(3.75f)
+                close()
+                moveTo(7.5f, 15.9915f)
+                lineTo(6.1969f, 14.6876f)
+                lineTo(12.8125f, 8.0711f)
+                lineTo(14.1164f, 9.3751f)
+                lineTo(7.5f, 15.9915f)
+                close()
+                moveTo(15.0f, 8.4915f)
+                lineTo(11.5094f, 5.0001f)
+                lineTo(13.3844f, 3.1251f)
+                lineTo(16.875f, 6.6165f)
+                lineTo(15.0f, 8.4915f)
+                close()
+            }
+        }
+        .build()
+        return requireNotNull(_pencilIcon)
+    }
+
+private var _pencilIcon: ImageVector? = null

--- a/app/src/main/java/com/soopeach/dowith/ui/icons/TodoIcon.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/icons/TodoIcon.kt
@@ -15,26 +15,16 @@ val TodoIcon: ImageVector
         if (_todoIcon != null) {
             return requireNotNull(_todoIcon)
         }
-        _todoIcon = Builder(name = "TodoIcon", defaultWidth = 24.0.dp, defaultHeight = 24.0.dp,
-                viewportWidth = 24.0f, viewportHeight = 24.0f).apply {
-            path(fill = SolidColor(Color(0xFFFF7F00)), stroke = null, strokeLineWidth = 0.0f,
-                    strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
-                    pathFillType = NonZero) {
-                moveTo(19.5f, 3.0f)
-                horizontalLineTo(4.5f)
-                curveTo(4.1022f, 3.0f, 3.7206f, 3.158f, 3.4393f, 3.4393f)
-                curveTo(3.158f, 3.7206f, 3.0f, 4.1022f, 3.0f, 4.5f)
-                verticalLineTo(19.5f)
-                curveTo(3.0f, 19.8978f, 3.158f, 20.2794f, 3.4393f, 20.5607f)
-                curveTo(3.7206f, 20.842f, 4.1022f, 21.0f, 4.5f, 21.0f)
-                horizontalLineTo(19.5f)
-                curveTo(19.8978f, 21.0f, 20.2794f, 20.842f, 20.5607f, 20.5607f)
-                curveTo(20.842f, 20.2794f, 21.0f, 19.8978f, 21.0f, 19.5f)
-                verticalLineTo(4.5f)
-                curveTo(21.0f, 4.1022f, 20.842f, 3.7206f, 20.5607f, 3.4393f)
-                curveTo(20.2794f, 3.158f, 19.8978f, 3.0f, 19.5f, 3.0f)
-                close()
-                moveTo(16.2806f, 10.2806f)
+        _todoIcon = Builder(name = "DoneIcon", defaultWidth = 24.0.dp, defaultHeight = 24.0.dp,
+            viewportWidth = 24.0f, viewportHeight = 24.0f).apply {
+            path(fill = SolidColor(Color(0xFFB7B7B7)), stroke = null, strokeLineWidth = 0.0f,
+                strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                pathFillType = NonZero) {
+                moveTo(16.2806f, 9.2194f)
+                curveTo(16.3504f, 9.289f, 16.4057f, 9.3717f, 16.4434f, 9.4628f)
+                curveTo(16.4812f, 9.5538f, 16.5006f, 9.6514f, 16.5006f, 9.75f)
+                curveTo(16.5006f, 9.8486f, 16.4812f, 9.9462f, 16.4434f, 10.0372f)
+                curveTo(16.4057f, 10.1283f, 16.3504f, 10.211f, 16.2806f, 10.2806f)
                 lineTo(11.0306f, 15.5306f)
                 curveTo(10.961f, 15.6004f, 10.8783f, 15.6557f, 10.7872f, 15.6934f)
                 curveTo(10.6962f, 15.7312f, 10.5986f, 15.7506f, 10.5f, 15.7506f)
@@ -47,14 +37,30 @@ val TodoIcon: ImageVector
                 curveTo(8.449f, 11.9996f, 8.6399f, 12.0786f, 8.7806f, 12.2194f)
                 lineTo(10.5f, 13.9397f)
                 lineTo(15.2194f, 9.2194f)
-                curveTo(15.2891f, 9.1497f, 15.3718f, 9.0944f, 15.4628f, 9.0567f)
-                curveTo(15.5539f, 9.019f, 15.6515f, 8.9996f, 15.75f, 8.9996f)
-                curveTo(15.8485f, 8.9996f, 15.9461f, 9.019f, 16.0372f, 9.0567f)
-                curveTo(16.1282f, 9.0944f, 16.2109f, 9.1497f, 16.2806f, 9.2194f)
-                curveTo(16.3503f, 9.2891f, 16.4056f, 9.3718f, 16.4433f, 9.4628f)
-                curveTo(16.481f, 9.5539f, 16.5004f, 9.6515f, 16.5004f, 9.75f)
-                curveTo(16.5004f, 9.8485f, 16.481f, 9.9461f, 16.4433f, 10.0372f)
-                curveTo(16.4056f, 10.1282f, 16.3503f, 10.2109f, 16.2806f, 10.2806f)
+                curveTo(15.289f, 9.1496f, 15.3717f, 9.0943f, 15.4628f, 9.0566f)
+                curveTo(15.5538f, 9.0188f, 15.6514f, 8.9994f, 15.75f, 8.9994f)
+                curveTo(15.8486f, 8.9994f, 15.9462f, 9.0188f, 16.0372f, 9.0566f)
+                curveTo(16.1283f, 9.0943f, 16.211f, 9.1496f, 16.2806f, 9.2194f)
+                close()
+                moveTo(21.0f, 4.5f)
+                verticalLineTo(19.5f)
+                curveTo(21.0f, 19.8978f, 20.842f, 20.2794f, 20.5607f, 20.5607f)
+                curveTo(20.2794f, 20.842f, 19.8978f, 21.0f, 19.5f, 21.0f)
+                horizontalLineTo(4.5f)
+                curveTo(4.1022f, 21.0f, 3.7206f, 20.842f, 3.4393f, 20.5607f)
+                curveTo(3.158f, 20.2794f, 3.0f, 19.8978f, 3.0f, 19.5f)
+                verticalLineTo(4.5f)
+                curveTo(3.0f, 4.1022f, 3.158f, 3.7206f, 3.4393f, 3.4393f)
+                curveTo(3.7206f, 3.158f, 4.1022f, 3.0f, 4.5f, 3.0f)
+                horizontalLineTo(19.5f)
+                curveTo(19.8978f, 3.0f, 20.2794f, 3.158f, 20.5607f, 3.4393f)
+                curveTo(20.842f, 3.7206f, 21.0f, 4.1022f, 21.0f, 4.5f)
+                close()
+                moveTo(19.5f, 19.5f)
+                verticalLineTo(4.5f)
+                horizontalLineTo(4.5f)
+                verticalLineTo(19.5f)
+                horizontalLineTo(19.5f)
                 close()
             }
         }

--- a/app/src/main/java/com/soopeach/dowith/ui/icons/TrashCanIcon.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/icons/TrashCanIcon.kt
@@ -1,0 +1,95 @@
+package com.soopeach.dowith.ui.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val TrashCanIcon: ImageVector
+    get() {
+        if (_trashCanIcon != null) {
+            return requireNotNull(_trashCanIcon)
+        }
+        _trashCanIcon = Builder(
+            name = "TrashCan", defaultWidth = 20.0.dp, defaultHeight = 20.0.dp,
+            viewportWidth = 20.0f, viewportHeight = 20.0f
+        ).apply {
+            path(
+                fill = SolidColor(Color(0xFF555555)), stroke = null, strokeLineWidth = 0.0f,
+                strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(16.875f, 3.75f)
+                horizontalLineTo(13.75f)
+                verticalLineTo(3.125f)
+                curveTo(13.75f, 2.6277f, 13.5525f, 2.1508f, 13.2008f, 1.7992f)
+                curveTo(12.8492f, 1.4475f, 12.3723f, 1.25f, 11.875f, 1.25f)
+                horizontalLineTo(8.125f)
+                curveTo(7.6277f, 1.25f, 7.1508f, 1.4475f, 6.7992f, 1.7992f)
+                curveTo(6.4475f, 2.1508f, 6.25f, 2.6277f, 6.25f, 3.125f)
+                verticalLineTo(3.75f)
+                horizontalLineTo(3.125f)
+                curveTo(2.9592f, 3.75f, 2.8003f, 3.8159f, 2.6831f, 3.9331f)
+                curveTo(2.5659f, 4.0503f, 2.5f, 4.2092f, 2.5f, 4.375f)
+                curveTo(2.5f, 4.5408f, 2.5659f, 4.6997f, 2.6831f, 4.8169f)
+                curveTo(2.8003f, 4.9342f, 2.9592f, 5.0f, 3.125f, 5.0f)
+                horizontalLineTo(3.75f)
+                verticalLineTo(16.25f)
+                curveTo(3.75f, 16.5815f, 3.8817f, 16.8995f, 4.1161f, 17.1339f)
+                curveTo(4.3505f, 17.3683f, 4.6685f, 17.5f, 5.0f, 17.5f)
+                horizontalLineTo(15.0f)
+                curveTo(15.3315f, 17.5f, 15.6495f, 17.3683f, 15.8839f, 17.1339f)
+                curveTo(16.1183f, 16.8995f, 16.25f, 16.5815f, 16.25f, 16.25f)
+                verticalLineTo(5.0f)
+                horizontalLineTo(16.875f)
+                curveTo(17.0408f, 5.0f, 17.1997f, 4.9342f, 17.3169f, 4.8169f)
+                curveTo(17.4342f, 4.6997f, 17.5f, 4.5408f, 17.5f, 4.375f)
+                curveTo(17.5f, 4.2092f, 17.4342f, 4.0503f, 17.3169f, 3.9331f)
+                curveTo(17.1997f, 3.8159f, 17.0408f, 3.75f, 16.875f, 3.75f)
+                close()
+                moveTo(8.75f, 13.125f)
+                curveTo(8.75f, 13.2908f, 8.6841f, 13.4497f, 8.5669f, 13.5669f)
+                curveTo(8.4497f, 13.6842f, 8.2908f, 13.75f, 8.125f, 13.75f)
+                curveTo(7.9592f, 13.75f, 7.8003f, 13.6842f, 7.6831f, 13.5669f)
+                curveTo(7.5658f, 13.4497f, 7.5f, 13.2908f, 7.5f, 13.125f)
+                verticalLineTo(8.125f)
+                curveTo(7.5f, 7.9592f, 7.5658f, 7.8003f, 7.6831f, 7.6831f)
+                curveTo(7.8003f, 7.5658f, 7.9592f, 7.5f, 8.125f, 7.5f)
+                curveTo(8.2908f, 7.5f, 8.4497f, 7.5658f, 8.5669f, 7.6831f)
+                curveTo(8.6841f, 7.8003f, 8.75f, 7.9592f, 8.75f, 8.125f)
+                verticalLineTo(13.125f)
+                close()
+                moveTo(12.5f, 13.125f)
+                curveTo(12.5f, 13.2908f, 12.4342f, 13.4497f, 12.3169f, 13.5669f)
+                curveTo(12.1997f, 13.6842f, 12.0408f, 13.75f, 11.875f, 13.75f)
+                curveTo(11.7092f, 13.75f, 11.5503f, 13.6842f, 11.4331f, 13.5669f)
+                curveTo(11.3158f, 13.4497f, 11.25f, 13.2908f, 11.25f, 13.125f)
+                verticalLineTo(8.125f)
+                curveTo(11.25f, 7.9592f, 11.3158f, 7.8003f, 11.4331f, 7.6831f)
+                curveTo(11.5503f, 7.5658f, 11.7092f, 7.5f, 11.875f, 7.5f)
+                curveTo(12.0408f, 7.5f, 12.1997f, 7.5658f, 12.3169f, 7.6831f)
+                curveTo(12.4342f, 7.8003f, 12.5f, 7.9592f, 12.5f, 8.125f)
+                verticalLineTo(13.125f)
+                close()
+                moveTo(12.5f, 3.75f)
+                horizontalLineTo(7.5f)
+                verticalLineTo(3.125f)
+                curveTo(7.5f, 2.9592f, 7.5658f, 2.8003f, 7.6831f, 2.6831f)
+                curveTo(7.8003f, 2.5659f, 7.9592f, 2.5f, 8.125f, 2.5f)
+                horizontalLineTo(11.875f)
+                curveTo(12.0408f, 2.5f, 12.1997f, 2.5659f, 12.3169f, 2.6831f)
+                curveTo(12.4342f, 2.8003f, 12.5f, 2.9592f, 12.5f, 3.125f)
+                verticalLineTo(3.75f)
+                close()
+            }
+        }
+            .build()
+        return requireNotNull(_trashCanIcon)
+    }
+
+private var _trashCanIcon: ImageVector? = null

--- a/app/src/main/java/com/soopeach/dowith/ui/screen/Screen.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/screen/Screen.kt
@@ -19,6 +19,8 @@ sealed class Screen(
     object TeamTodoMain : Screen("teamTodoMain", R.string.team_todo, TeamTodoMenu)
     object Done : Screen("done", R.string.done, DoneMenu)
 
+    object PersonalTodoMore : Screen("personalTodoMore")
+
     companion object {
         val bottomNavigationItems = listOf(PersonalTodoMain, TeamTodoMain, Done)
     }

--- a/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMainScreen.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMainScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -29,6 +30,10 @@ fun PersonalTodoMainScreen(
 
     val viewModel = hiltViewModel<PersonalTodoMainViewModel>()
     val state by viewModel.collectAsState()
+
+    LaunchedEffect(true) {
+        viewModel.getTodayTodoItems()
+    }
 
     PersonalTodoMainContent(
         state,

--- a/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMainScreen.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMainScreen.kt
@@ -16,6 +16,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.soopeach.dowith.ui.component.DoWithTopBar
 import com.soopeach.dowith.ui.component.SimplifiedTodoContainer
+import com.soopeach.dowith.ui.screen.Screen
 import com.soopeach.dowith.ui.theme.DoWithColors
 import com.soopeach.dowith.viewmodel.PersonalTodoMainState
 import com.soopeach.dowith.viewmodel.PersonalTodoMainViewModel
@@ -29,16 +30,23 @@ fun PersonalTodoMainScreen(
     val viewModel = hiltViewModel<PersonalTodoMainViewModel>()
     val state by viewModel.collectAsState()
 
-    PersonalTodoMainContent(state) {
-        viewModel.setTodoToggle(it)
-    }
+    PersonalTodoMainContent(
+        state,
+        onTodoItemClicked = {
+            viewModel.setTodoToggle(it)
+        },
+        onMoreClicked = {
+            navController.navigate(Screen.PersonalTodoMore.route)
+        }
+    )
 
 }
 
 @Composable
 fun PersonalTodoMainContent(
     state: PersonalTodoMainState,
-    onTodoItemClicked: (Long) -> Unit = {}
+    onTodoItemClicked: (Long) -> Unit = {},
+    onMoreClicked: () -> Unit = {}
 ) {
     Scaffold(
         topBar = {
@@ -64,7 +72,9 @@ fun PersonalTodoMainContent(
             state.todayTodoItems.getDataOrNull()?.let { todoItems ->
                 SimplifiedTodoContainer(todoItems.take(2), onTodoIconClicked = {
                     onTodoItemClicked(it)
-                })
+                }) {
+                    onMoreClicked()
+                }
             }
         }
     }

--- a/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMoreScreen.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMoreScreen.kt
@@ -70,6 +70,9 @@ fun PersonalTodoMoreScreen(
         onTopBarNavigationIconClicked = {
             navController.popBackStack()
         },
+        onDeleteMenuClicked = {
+            viewModel.deleteTodoItem(it)
+        },
         onTodoItemClicked = {
             viewModel.setTodoToggle(it)
         },
@@ -87,6 +90,7 @@ fun PersonalTodoMoreScreen(
 fun PersonalTodoMoreContent(
     state: PersonalTodoMoreState,
     onTopBarNavigationIconClicked: () -> Unit = {},
+    onDeleteMenuClicked: (Long) -> Unit = {},
     onTodoItemClicked: (Long) -> Unit = {},
     onKeyboardActionClicked: (Long, String) -> Unit,
     onTodoContentChanged: (Long, String) -> Unit,
@@ -135,7 +139,10 @@ fun PersonalTodoMoreContent(
                     }
                 },
                 onDeleteButtonClicked = {
-
+                    onDeleteMenuClicked(targetTodoItemId)
+                    bottomSheetScope.launch {
+                        bottomSheetState.hide()
+                    }
                 }
             ) {
 

--- a/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMoreScreen.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMoreScreen.kt
@@ -81,7 +81,12 @@ fun PersonalTodoMoreScreen(
         },
         onTodoContentChanged = { id, content ->
             viewModel.modifyTodoContentInMemory(id, content)
-        }
+        },
+        onCompleteButtonClicked = { todoContents ->
+            todoContents.forEach {  content ->
+                viewModel.postTodoItem(content)
+            }
+        },
     )
 }
 
@@ -94,9 +99,10 @@ fun PersonalTodoMoreContent(
     onTodoItemClicked: (Long) -> Unit = {},
     onKeyboardActionClicked: (Long, String) -> Unit,
     onTodoContentChanged: (Long, String) -> Unit,
+    onCompleteButtonClicked: (List<String>) -> Unit = {},
 ) {
 
-    val focusState = LocalFocusManager.current
+    val focusManager = LocalFocusManager.current
 
     val focusRequester = FocusRequester()
 
@@ -110,7 +116,7 @@ fun PersonalTodoMoreContent(
     val bottomSheetState = rememberModalBottomSheetState(
         initialValue = ModalBottomSheetValue.Hidden,
         confirmValueChange = { it != ModalBottomSheetValue.HalfExpanded },
-        skipHalfExpanded = false
+        skipHalfExpanded = true
     )
 
     state.todayTodoItems.getDataOrNull()?.let { todoItems ->
@@ -143,6 +149,9 @@ fun PersonalTodoMoreContent(
                     bottomSheetScope.launch {
                         bottomSheetState.hide()
                     }
+                },
+                onCompleteButtonClicked = {
+                    onCompleteButtonClicked(it)
                 }
             ) {
 
@@ -246,7 +255,7 @@ fun PersonalTodoMoreContent(
                                                 }
                                             },
                                             onKeyboardActionClicked = {
-                                                focusState.clearFocus()
+                                                focusManager.clearFocus()
                                                 onKeyboardActionClicked(
                                                     todoItem.id,
                                                     todoItem.content

--- a/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMoreScreen.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMoreScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBackIosNew
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -59,6 +60,10 @@ fun PersonalTodoMoreScreen(
 
     val viewModel = hiltViewModel<PersonalTodoMoreViewModel>()
     val state by viewModel.collectAsState()
+
+    LaunchedEffect(true) {
+        viewModel.getTodayTodoItems()
+    }
 
     PersonalTodoMoreContent(
         state = state,

--- a/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMoreScreen.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMoreScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
@@ -79,11 +81,8 @@ fun PersonalTodoMoreScreen(
         onKeyboardActionClicked = { id, content ->
             viewModel.modifyTodoContent(id, content)
         },
-        onTodoContentChanged = { id, content ->
-            viewModel.modifyTodoContentInMemory(id, content)
-        },
         onCompleteButtonClicked = { todoContents ->
-            todoContents.forEach {  content ->
+            todoContents.forEach { content ->
                 viewModel.postTodoItem(content)
             }
         },
@@ -98,7 +97,6 @@ fun PersonalTodoMoreContent(
     onDeleteMenuClicked: (Long) -> Unit = {},
     onTodoItemClicked: (Long) -> Unit = {},
     onKeyboardActionClicked: (Long, String) -> Unit,
-    onTodoContentChanged: (Long, String) -> Unit,
     onCompleteButtonClicked: (List<String>) -> Unit = {},
 ) {
 
@@ -254,17 +252,12 @@ fun PersonalTodoMoreContent(
                                                     bottomSheetState.show()
                                                 }
                                             },
-                                            onKeyboardActionClicked = {
+                                            onKeyboardActionClicked = { changedContent ->
                                                 focusManager.clearFocus()
-                                                onKeyboardActionClicked(
-                                                    todoItem.id,
-                                                    todoItem.content
-                                                )
+                                                onKeyboardActionClicked(todoItem.id, changedContent)
                                                 targetTodoItemId = TodoItem.NOT_SELECTED
                                             }
-                                        ) { changedText ->
-                                            onTodoContentChanged(todoItem.id, changedText)
-                                        }
+                                        )
                                     }
                                 }
                             }

--- a/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMoreScreen.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMoreScreen.kt
@@ -1,0 +1,215 @@
+package com.soopeach.dowith.ui.screen.personal
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Icon
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBackIosNew
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import com.soopeach.dowith.ui.component.DoWithTopBar
+import com.soopeach.dowith.ui.component.NicknameTodoListExplainText
+import com.soopeach.dowith.ui.component.bottomsheet.TodoContainerModalBottomSheetLayout
+import com.soopeach.dowith.ui.component.bottomsheet.TodoContainerModalBottomSheetType
+import com.soopeach.dowith.ui.component.TodoItemComposable
+import com.soopeach.dowith.ui.icons.CheckBoxIcon
+import com.soopeach.dowith.ui.icons.PencilIcon
+import com.soopeach.dowith.ui.theme.DoWithColors
+import com.soopeach.dowith.ui.theme.DoWithTypography
+import com.soopeach.dowith.viewmodel.PersonalTodoMoreState
+import com.soopeach.dowith.viewmodel.PersonalTodoMoreViewModel
+import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.compose.collectAsState
+
+@Composable
+fun PersonalTodoMoreScreen(
+    navController: NavController,
+) {
+
+    val viewModel = hiltViewModel<PersonalTodoMoreViewModel>()
+    val state by viewModel.collectAsState()
+
+    PersonalTodoMoreContent(
+        state = state,
+        onTopBarNavigationIconClicked = {
+            navController.popBackStack()
+        },
+        onTodoItemClicked = {
+            viewModel.setTodoToggle(it)
+        },
+    )
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun PersonalTodoMoreContent(
+    state: PersonalTodoMoreState,
+    onTopBarNavigationIconClicked: () -> Unit = {},
+    onTodoItemClicked: (Long) -> Unit = {},
+) {
+
+    var bottomSheetType: TodoContainerModalBottomSheetType by remember {
+        mutableStateOf(TodoContainerModalBottomSheetType.More)
+    }
+    val bottomSheetScope = rememberCoroutineScope()
+    val bottomSheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden,
+        confirmValueChange = { it != ModalBottomSheetValue.HalfExpanded },
+        skipHalfExpanded = false
+    )
+
+    state.todayTodoItems.getDataOrNull()?.let { todoItems ->
+        Scaffold(
+            topBar = {
+                DoWithTopBar(
+                    navigationIcon = {
+                        Icon(
+                            modifier = Modifier.clickable {
+                                onTopBarNavigationIconClicked()
+                            },
+                            imageVector = Icons.Filled.ArrowBackIosNew, contentDescription = "뒤로가기",
+                        )
+                    }
+                )
+            }
+        ) { paddingValues ->
+            TodoContainerModalBottomSheetLayout(
+                bottomSheetType,
+                bottomSheetScope,
+                bottomSheetState,
+                onModifyButtonClicked = {
+
+                },
+                onDeleteButtonClicked = {
+
+                }
+            ) {
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues)
+                        .padding(horizontal = 20.dp)
+                ) {
+
+                    Spacer(modifier = Modifier.height(10.dp))
+
+                    // TODO: User name
+                    NicknameTodoListExplainText(nickname = "두잇츄")
+
+                    Spacer(modifier = Modifier.height(18.dp))
+
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(400.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(DoWithColors.gray100)
+
+                    ) {
+
+                        Column(
+                            modifier = Modifier
+                                .matchParentSize()
+                                .padding(20.dp)
+                        ) {
+
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                            ) {
+
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(3.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Icon(
+                                        CheckBoxIcon, contentDescription = "체크박스 아이콘",
+                                        tint = DoWithColors.orange1000
+                                    )
+                                    Text(
+                                        text = "오늘의 할 일!",
+                                        style = DoWithTypography.Title3.copy(DoWithColors.gray800)
+                                    )
+                                }
+
+                                Row(
+                                    modifier = Modifier.clickable {
+                                        bottomSheetType = TodoContainerModalBottomSheetType.Write
+                                        bottomSheetScope.launch {
+                                            bottomSheetState.show()
+                                        }
+                                    },
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Icon(
+                                        PencilIcon, contentDescription = "작성하기 아이콘",
+                                        tint = DoWithColors.gray500
+                                    )
+                                    Text(
+                                        text = "작성하기",
+                                        style = DoWithTypography.Body3.copy(DoWithColors.gray500)
+                                    )
+                                }
+
+                            }
+
+                            Spacer(modifier = Modifier.height(28.dp))
+
+                            LazyColumn(
+                                verticalArrangement = Arrangement.spacedBy(16.dp)
+                            ) {
+
+                                todoItems.forEach {
+                                    item {
+                                        TodoItemComposable(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            todoItem = it, isMoreIconVisible = true,
+                                            onTodoIconClicked = {
+                                                onTodoItemClicked(it.id)
+                                            },
+                                            onMoreIconClicked = {
+                                                bottomSheetType = TodoContainerModalBottomSheetType.More
+                                                bottomSheetScope.launch {
+                                                    bottomSheetState.show()
+                                                }
+                                            })
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+}

--- a/app/src/main/java/com/soopeach/dowith/viewmodel/PersonalTodoMainViewModel.kt
+++ b/app/src/main/java/com/soopeach/dowith/viewmodel/PersonalTodoMainViewModel.kt
@@ -30,11 +30,7 @@ class PersonalTodoMainViewModel @Inject constructor(
     override val container =
         container<PersonalTodoMainState, PersonalTodoMainSideEffect>(PersonalTodoMainState())
 
-    init {
-        getTodayTodoItems()
-    }
-
-    private fun getTodayTodoItems() = intent {
+    fun getTodayTodoItems() = intent {
         reduce {
             state.copy(todayTodoItems = UiState.Loading)
         }
@@ -48,14 +44,16 @@ class PersonalTodoMainViewModel @Inject constructor(
     fun setTodoToggle(id: Long) = intent {
 
         // TODO: Error Handling
-        postTodoToggleUseCase(id)
+        val toggleChangedPost = postTodoToggleUseCase(id)
         reduce {
-            val previousTodoItems = state.todayTodoItems.getDataOrNull() ?: emptyList()
             state.copy(todayTodoItems = UiState.Success(
                 previousTodoItems.map {
-                    if (it.id == id) it.copy(isChecked = it.isChecked.not()) else it
+                    if (it.id == toggleChangedPost.id) toggleChangedPost else it
                 }
             ))
         }
     }
+
+    private val previousTodoItems: List<TodoItem>
+        get() = container.stateFlow.value.todayTodoItems.getDataOrNull() ?: emptyList()
 }

--- a/app/src/main/java/com/soopeach/dowith/viewmodel/PersonalTodoMoreViewModel.kt
+++ b/app/src/main/java/com/soopeach/dowith/viewmodel/PersonalTodoMoreViewModel.kt
@@ -31,11 +31,7 @@ class PersonalTodoMoreViewModel @Inject constructor(
     override val container =
         container<PersonalTodoMoreState, PersonalTodoMoreSideEffect>(PersonalTodoMoreState())
 
-    init {
-        getTodayTodoItems()
-    }
-
-    private fun getTodayTodoItems() = intent {
+    fun getTodayTodoItems() = intent {
         reduce {
             state.copy(todayTodoItems = UiState.Loading)
         }
@@ -49,12 +45,11 @@ class PersonalTodoMoreViewModel @Inject constructor(
     fun setTodoToggle(id: Long) = intent {
 
         // TODO: Error Handling
-        postTodoToggleUseCase(id)
+        val toggleChangedPost = postTodoToggleUseCase(id)
         reduce {
-            val previousTodoItems = state.todayTodoItems.getDataOrNull() ?: emptyList()
             state.copy(todayTodoItems = UiState.Success(
                 previousTodoItems.map {
-                    if (it.id == id) it.copy(isChecked = it.isChecked.not()) else it
+                    if (it.id == toggleChangedPost.id) toggleChangedPost else it
                 }
             ))
         }
@@ -62,7 +57,6 @@ class PersonalTodoMoreViewModel @Inject constructor(
 
     fun modifyTodoContentInMemory(id: Long, content: String) = intent {
         reduce {
-            val previousTodoItems = state.todayTodoItems.getDataOrNull() ?: emptyList()
             state.copy(todayTodoItems = UiState.Success(
                 previousTodoItems.map {
                     if (it.id == id) it.copy(content = content) else it
@@ -74,7 +68,6 @@ class PersonalTodoMoreViewModel @Inject constructor(
     fun modifyTodoContent(id: Long, content: String) = intent {
         val modifiedTodoItem = modifyTodoContentUseCase(id, content)
         reduce {
-            val previousTodoItems = state.todayTodoItems.getDataOrNull() ?: emptyList()
             state.copy(todayTodoItems = UiState.Success(
                 previousTodoItems.map {
                     if (it.id == id) modifiedTodoItem else it
@@ -82,4 +75,7 @@ class PersonalTodoMoreViewModel @Inject constructor(
             ))
         }
     }
+
+    private val previousTodoItems: List<TodoItem>
+        get() = container.stateFlow.value.todayTodoItems.getDataOrNull() ?: emptyList()
 }

--- a/app/src/main/java/com/soopeach/dowith/viewmodel/PersonalTodoMoreViewModel.kt
+++ b/app/src/main/java/com/soopeach/dowith/viewmodel/PersonalTodoMoreViewModel.kt
@@ -2,6 +2,7 @@ package com.soopeach.dowith.viewmodel
 
 import androidx.lifecycle.ViewModel
 import com.soopeach.domain.model.TodoItem
+import com.soopeach.domain.usecase.DeleteTodoUseCase
 import com.soopeach.domain.usecase.GetTodayTodoItemsUseCase
 import com.soopeach.domain.usecase.ModifyTodoContentUseCase
 import com.soopeach.domain.usecase.PostTodoToggleUseCase
@@ -26,6 +27,7 @@ class PersonalTodoMoreViewModel @Inject constructor(
     private val getTodayTodoItemsUseCase: GetTodayTodoItemsUseCase,
     private val postTodoToggleUseCase: PostTodoToggleUseCase,
     private val modifyTodoContentUseCase: ModifyTodoContentUseCase,
+    private val deleteTodoUseCase: DeleteTodoUseCase
 ) : ViewModel(), ContainerHost<PersonalTodoMoreState, PersonalTodoMoreSideEffect> {
 
     override val container =
@@ -73,6 +75,15 @@ class PersonalTodoMoreViewModel @Inject constructor(
                     if (it.id == id) modifiedTodoItem else it
                 }
             ))
+        }
+    }
+
+    // TODO: Todo Item Delete
+    fun deleteTodoItem(id: Long) = intent {
+        deleteTodoUseCase(id).let { isDeleted ->
+            if (isDeleted) {
+                getTodayTodoItems()
+            }
         }
     }
 

--- a/app/src/main/java/com/soopeach/dowith/viewmodel/PersonalTodoMoreViewModel.kt
+++ b/app/src/main/java/com/soopeach/dowith/viewmodel/PersonalTodoMoreViewModel.kt
@@ -59,18 +59,10 @@ class PersonalTodoMoreViewModel @Inject constructor(
         }
     }
 
-    fun modifyTodoContentInMemory(id: Long, content: String) = intent {
-        reduce {
-            state.copy(todayTodoItems = UiState.Success(
-                previousTodoItems.map {
-                    if (it.id == id) it.copy(content = content) else it
-                }
-            ))
-        }
-    }
-
     fun modifyTodoContent(id: Long, content: String) = intent {
+
         val modifiedTodoItem = modifyTodoContentUseCase(id, content)
+
         reduce {
             state.copy(todayTodoItems = UiState.Success(
                 previousTodoItems.map {

--- a/app/src/main/java/com/soopeach/dowith/viewmodel/PersonalTodoMoreViewModel.kt
+++ b/app/src/main/java/com/soopeach/dowith/viewmodel/PersonalTodoMoreViewModel.kt
@@ -1,0 +1,59 @@
+package com.soopeach.dowith.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.soopeach.domain.model.TodoItem
+import com.soopeach.domain.usecase.GetTodayTodoItemsUseCase
+import com.soopeach.domain.usecase.PostTodoToggleUseCase
+import com.soopeach.dowith.model.UiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.container
+import javax.inject.Inject
+
+sealed class PersonalTodoMoreSideEffect {
+
+}
+
+data class PersonalTodoMoreState(
+    val todayTodoItems: UiState<List<TodoItem>> = UiState.Idle
+)
+
+@HiltViewModel
+class PersonalTodoMoreViewModel @Inject constructor(
+    private val getTodayTodoItemsUseCase: GetTodayTodoItemsUseCase,
+    private val postTodoToggleUseCase: PostTodoToggleUseCase
+): ViewModel(), ContainerHost<PersonalTodoMoreState, PersonalTodoMoreSideEffect> {
+
+    override val container = container<PersonalTodoMoreState, PersonalTodoMoreSideEffect>(PersonalTodoMoreState())
+
+    init {
+        getTodayTodoItems()
+    }
+
+    private fun getTodayTodoItems() = intent {
+        reduce {
+            state.copy(todayTodoItems = UiState.Loading)
+        }
+        val todoItems = getTodayTodoItemsUseCase()
+        reduce {
+            state.copy(todayTodoItems = UiState.Success(todoItems))
+        }
+    }
+
+    // TODO: Todo Item Toggle UseCase
+    fun setTodoToggle(id: Long) = intent {
+
+        // TODO: Error Handling
+        postTodoToggleUseCase(id)
+        reduce {
+            val previousTodoItems = state.todayTodoItems.getDataOrNull() ?: emptyList()
+            state.copy(todayTodoItems = UiState.Success(
+                previousTodoItems.map {
+                    if (it.id == id) it.copy(isChecked = it.isChecked.not()) else it
+                }
+            ))
+        }
+    }
+}

--- a/app/src/main/java/com/soopeach/dowith/viewmodel/PersonalTodoMoreViewModel.kt
+++ b/app/src/main/java/com/soopeach/dowith/viewmodel/PersonalTodoMoreViewModel.kt
@@ -6,6 +6,7 @@ import com.soopeach.domain.usecase.DeleteTodoUseCase
 import com.soopeach.domain.usecase.GetTodayTodoItemsUseCase
 import com.soopeach.domain.usecase.ModifyTodoContentUseCase
 import com.soopeach.domain.usecase.PostTodoToggleUseCase
+import com.soopeach.domain.usecase.PostTodoUseCase
 import com.soopeach.dowith.model.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.ContainerHost
@@ -27,7 +28,8 @@ class PersonalTodoMoreViewModel @Inject constructor(
     private val getTodayTodoItemsUseCase: GetTodayTodoItemsUseCase,
     private val postTodoToggleUseCase: PostTodoToggleUseCase,
     private val modifyTodoContentUseCase: ModifyTodoContentUseCase,
-    private val deleteTodoUseCase: DeleteTodoUseCase
+    private val deleteTodoUseCase: DeleteTodoUseCase,
+    private val postTodoUseCase: PostTodoUseCase
 ) : ViewModel(), ContainerHost<PersonalTodoMoreState, PersonalTodoMoreSideEffect> {
 
     override val container =
@@ -84,6 +86,17 @@ class PersonalTodoMoreViewModel @Inject constructor(
             if (isDeleted) {
                 getTodayTodoItems()
             }
+        }
+    }
+
+    fun postTodoItem(content: String) = intent {
+        val newTodoItem = postTodoUseCase(content)
+        reduce {
+            state.copy(
+                todayTodoItems = UiState.Success(
+                    previousTodoItems + newTodoItem
+                )
+            )
         }
     }
 

--- a/data/src/main/java/com/soopeach/data/datasource/TodoDataSource.kt
+++ b/data/src/main/java/com/soopeach/data/datasource/TodoDataSource.kt
@@ -11,4 +11,6 @@ interface TodoDataSource {
     suspend fun putTodoContent(id: Long, content: String): TodoItem
 
     suspend fun deleteTodoItem(id: Long): Boolean
+
+    suspend fun postTodoItem(content: String): TodoItem
 }

--- a/data/src/main/java/com/soopeach/data/datasource/TodoDataSource.kt
+++ b/data/src/main/java/com/soopeach/data/datasource/TodoDataSource.kt
@@ -9,4 +9,6 @@ interface TodoDataSource {
     suspend fun postTodoToggle(id: Long): TodoItem
 
     suspend fun putTodoContent(id: Long, content: String): TodoItem
+
+    suspend fun deleteTodoItem(id: Long): Boolean
 }

--- a/data/src/main/java/com/soopeach/data/datasource/TodoDataSource.kt
+++ b/data/src/main/java/com/soopeach/data/datasource/TodoDataSource.kt
@@ -7,4 +7,6 @@ interface TodoDataSource {
     suspend fun getTodayTodoItems(): List<TodoItem>
 
     suspend fun postTodoToggle(id: Long): TodoItem
+
+    suspend fun putTodoContent(id: Long, content: String): TodoItem
 }

--- a/data/src/main/java/com/soopeach/data/datasource/TodoDataSourceImpl.kt
+++ b/data/src/main/java/com/soopeach/data/datasource/TodoDataSourceImpl.kt
@@ -17,7 +17,8 @@ class TodoDataSourceImpl @Inject constructor(
 
     override suspend fun postTodoToggle(id: Long): TodoItem {
         // TODO: Call Api
-        dummyItems = dummyItems.map { if (it.id == id) it.copy(isChecked = it.isChecked.not()) else it }
+        dummyItems =
+            dummyItems.map { if (it.id == id) it.copy(isChecked = it.isChecked.not()) else it }
         return dummyItems.first { it.id == id }
     }
 
@@ -31,5 +32,12 @@ class TodoDataSourceImpl @Inject constructor(
         // TODO: Call Api
         dummyItems = dummyItems.filter { it.id != id }
         return true
+    }
+
+    override suspend fun postTodoItem(content: String): TodoItem {
+        // TODO: Call Api
+        val newTodoItem = TodoItem.DUMMY.copy(content = content, isChecked = false)
+        dummyItems = dummyItems + newTodoItem
+        return newTodoItem
     }
 }

--- a/data/src/main/java/com/soopeach/data/datasource/TodoDataSourceImpl.kt
+++ b/data/src/main/java/com/soopeach/data/datasource/TodoDataSourceImpl.kt
@@ -26,4 +26,10 @@ class TodoDataSourceImpl @Inject constructor(
         dummyItems = dummyItems.map { if (it.id == id) it.copy(content = content) else it }
         return dummyItems.first { it.id == id }
     }
+
+    override suspend fun deleteTodoItem(id: Long): Boolean {
+        // TODO: Call Api
+        dummyItems = dummyItems.filter { it.id != id }
+        return true
+    }
 }

--- a/data/src/main/java/com/soopeach/data/datasource/TodoDataSourceImpl.kt
+++ b/data/src/main/java/com/soopeach/data/datasource/TodoDataSourceImpl.kt
@@ -8,7 +8,7 @@ class TodoDataSourceImpl @Inject constructor(
     private val client: Retrofit
 ) : TodoDataSource {
 
-    private val dummyItems = List(10) { TodoItem.DUMMY }
+    private var dummyItems = List(10) { TodoItem.DUMMY }
 
     override suspend fun getTodayTodoItems(): List<TodoItem> {
         // TODO: Call Api
@@ -17,6 +17,12 @@ class TodoDataSourceImpl @Inject constructor(
 
     override suspend fun postTodoToggle(id: Long): TodoItem {
         // TODO: Call Api
+        return dummyItems.first { it.id == id }
+    }
+
+    override suspend fun putTodoContent(id: Long, content: String): TodoItem {
+        // TODO: Call Api
+        dummyItems.map { if (it.id == id) it.copy(content = content) else it }
         return dummyItems.first { it.id == id }
     }
 }

--- a/data/src/main/java/com/soopeach/data/datasource/TodoDataSourceImpl.kt
+++ b/data/src/main/java/com/soopeach/data/datasource/TodoDataSourceImpl.kt
@@ -17,12 +17,13 @@ class TodoDataSourceImpl @Inject constructor(
 
     override suspend fun postTodoToggle(id: Long): TodoItem {
         // TODO: Call Api
+        dummyItems = dummyItems.map { if (it.id == id) it.copy(isChecked = it.isChecked.not()) else it }
         return dummyItems.first { it.id == id }
     }
 
     override suspend fun putTodoContent(id: Long, content: String): TodoItem {
         // TODO: Call Api
-        dummyItems.map { if (it.id == id) it.copy(content = content) else it }
+        dummyItems = dummyItems.map { if (it.id == id) it.copy(content = content) else it }
         return dummyItems.first { it.id == id }
     }
 }

--- a/data/src/main/java/com/soopeach/data/repository/TodoRepositoryImpl.kt
+++ b/data/src/main/java/com/soopeach/data/repository/TodoRepositoryImpl.kt
@@ -23,4 +23,8 @@ class TodoRepositoryImpl @Inject constructor(
     override suspend fun deleteTodoItem(id: Long): Boolean {
         return todoDataSource.deleteTodoItem(id)
     }
+
+    override suspend fun postTodoItem(content: String): TodoItem {
+        return todoDataSource.postTodoItem(content)
+    }
 }

--- a/data/src/main/java/com/soopeach/data/repository/TodoRepositoryImpl.kt
+++ b/data/src/main/java/com/soopeach/data/repository/TodoRepositoryImpl.kt
@@ -15,4 +15,8 @@ class TodoRepositoryImpl @Inject constructor(
     override suspend fun postTodoToggle(id: Long): TodoItem {
         return todoDataSource.postTodoToggle(id)
     }
+
+    override suspend fun putTodoContent(id: Long, content: String): TodoItem {
+        return todoDataSource.putTodoContent(id, content)
+    }
 }

--- a/data/src/main/java/com/soopeach/data/repository/TodoRepositoryImpl.kt
+++ b/data/src/main/java/com/soopeach/data/repository/TodoRepositoryImpl.kt
@@ -19,4 +19,8 @@ class TodoRepositoryImpl @Inject constructor(
     override suspend fun putTodoContent(id: Long, content: String): TodoItem {
         return todoDataSource.putTodoContent(id, content)
     }
+
+    override suspend fun deleteTodoItem(id: Long): Boolean {
+        return todoDataSource.deleteTodoItem(id)
+    }
 }

--- a/domain/src/main/java/com/soopeach/domain/model/TodoItem.kt
+++ b/domain/src/main/java/com/soopeach/domain/model/TodoItem.kt
@@ -26,5 +26,7 @@ data class TodoItem(
                 "2023-05-30T10:04:22.139Z",
                 listOf(true, false).shuffled().first()
             )
+
+        const val NOT_SELECTED = -1L
     }
 }

--- a/domain/src/main/java/com/soopeach/domain/repository/TodoRepository.kt
+++ b/domain/src/main/java/com/soopeach/domain/repository/TodoRepository.kt
@@ -7,4 +7,6 @@ interface TodoRepository {
     suspend fun getTodayTodoItems(): List<TodoItem>
 
     suspend fun postTodoToggle(id: Long): TodoItem
+
+    suspend fun putTodoContent(id: Long, content: String): TodoItem
 }

--- a/domain/src/main/java/com/soopeach/domain/repository/TodoRepository.kt
+++ b/domain/src/main/java/com/soopeach/domain/repository/TodoRepository.kt
@@ -11,4 +11,6 @@ interface TodoRepository {
     suspend fun putTodoContent(id: Long, content: String): TodoItem
 
     suspend fun deleteTodoItem(id: Long): Boolean
+
+    suspend fun postTodoItem(content: String): TodoItem
 }

--- a/domain/src/main/java/com/soopeach/domain/repository/TodoRepository.kt
+++ b/domain/src/main/java/com/soopeach/domain/repository/TodoRepository.kt
@@ -9,4 +9,6 @@ interface TodoRepository {
     suspend fun postTodoToggle(id: Long): TodoItem
 
     suspend fun putTodoContent(id: Long, content: String): TodoItem
+
+    suspend fun deleteTodoItem(id: Long): Boolean
 }

--- a/domain/src/main/java/com/soopeach/domain/usecase/DeleteTodoUseCase.kt
+++ b/domain/src/main/java/com/soopeach/domain/usecase/DeleteTodoUseCase.kt
@@ -1,0 +1,13 @@
+package com.soopeach.domain.usecase
+
+import com.soopeach.domain.repository.TodoRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DeleteTodoUseCase @Inject constructor(
+    private val todoRepository: TodoRepository
+){
+
+    suspend operator fun invoke(id: Long) = todoRepository.deleteTodoItem(id)
+}

--- a/domain/src/main/java/com/soopeach/domain/usecase/ModifyTodoContentUseCase.kt
+++ b/domain/src/main/java/com/soopeach/domain/usecase/ModifyTodoContentUseCase.kt
@@ -1,0 +1,16 @@
+package com.soopeach.domain.usecase
+
+import com.soopeach.domain.model.TodoItem
+import com.soopeach.domain.repository.TodoRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ModifyTodoContentUseCase @Inject constructor(
+    private val todoRepository: TodoRepository
+) {
+
+    suspend operator fun invoke(id: Long, content: String): TodoItem {
+        return todoRepository.putTodoContent(id, content)
+    }
+}

--- a/domain/src/main/java/com/soopeach/domain/usecase/PostTodoUseCase.kt
+++ b/domain/src/main/java/com/soopeach/domain/usecase/PostTodoUseCase.kt
@@ -1,0 +1,13 @@
+package com.soopeach.domain.usecase
+
+import com.soopeach.domain.repository.TodoRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PostTodoUseCase @Inject constructor(
+    private val todoRepository: TodoRepository
+){
+
+    suspend operator fun invoke(content: String) = todoRepository.postTodoItem(content)
+}

--- a/domain/src/main/java/com/soopeach/domain/utils/extensions.kt
+++ b/domain/src/main/java/com/soopeach/domain/utils/extensions.kt
@@ -1,0 +1,4 @@
+package com.soopeach.domain.utils
+
+val String.Companion.empty: String
+    get() = ""


### PR DESCRIPTION
## 개요
- 로컬 더미 데이터를 활용해서 실제로 앱이 동작하는 것처럼 보이도록 변경
- 투두 수정 기능 구현
- 투두 삭제 기능 구현
- 투두 등록 기능 구현

## 동작 모습

- 로컬 더미 데이터 활용


![local](https://github.com/Do-It-Do-It-Chu/Dowith-Android/assets/90144041/be577ca8-16e5-4b79-8656-df7297e18e86)


- 투두 수정 기능

![modify](https://github.com/Do-It-Do-It-Chu/Dowith-Android/assets/90144041/1f57f3c8-9be6-430b-bda5-ea8c734eb15e)


- 투두 삭제 기능

![delete](https://github.com/Do-It-Do-It-Chu/Dowith-Android/assets/90144041/985e992b-3905-4ff5-989a-7e996a7be031)


- 투두 등록 기능

![register](https://github.com/Do-It-Do-It-Chu/Dowith-Android/assets/90144041/f03758ce-2a72-4eeb-bd92-da9a2c7a05dd)

