### PR TITLE
개인 투두 메인 페이지에서 투두 작성 기능 추가

### DIFF
--- a/app/src/main/java/com/soopeach/dowith/ui/component/SimplifiedTodoContainer.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/component/SimplifiedTodoContainer.kt
@@ -21,18 +21,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
-import com.soopeach.domain.model.TodoItem
 import com.soopeach.dowith.ui.icons.CheckBoxIcon
 import com.soopeach.dowith.ui.theme.DoWithColors
 import com.soopeach.dowith.ui.theme.DoWithTypography
 
 @Composable
 fun SimplifiedTodoContainer(
-    todoItems: List<TodoItem>,
-    onTodoIconClicked: (Long) -> Unit = {},
-    onMoreIconClicked: () -> Unit = {}
+    onMoreClicked: () -> Unit = {},
+    content: @Composable () -> Unit
 ) {
-
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -63,7 +60,7 @@ fun SimplifiedTodoContainer(
 
                 Row(
                     modifier = Modifier.clickable {
-                        onMoreIconClicked()
+                        onMoreClicked()
                     },
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -82,18 +79,8 @@ fun SimplifiedTodoContainer(
             }
 
             Spacer(modifier = Modifier.height(20.dp))
-            todoItems.forEach {
-                TodoItemComposable(
-                    todoItem = it,
-                    modifier = Modifier.fillMaxWidth(),
-                    isMoreIconVisible = false,
-                    onTodoIconClicked = {
-                        onTodoIconClicked(it.id)
-                    }
-                )
 
-                Spacer(modifier = Modifier.height(16.dp))
-            }
+            content()
         }
 
     }

--- a/app/src/main/java/com/soopeach/dowith/ui/component/bottomsheet/TodoContainerModalBottomSheetLayout.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/component/bottomsheet/TodoContainerModalBottomSheetLayout.kt
@@ -65,9 +65,7 @@ fun TodoContainerModalBottomSheetLayout(
     onModifyButtonClicked: () -> Unit = {},
     onDeleteButtonClicked: () -> Unit = {},
     onCompleteButtonClicked: (List<String>) -> Unit = {},
-    content: @Composable () -> Unit = {
-
-    },
+    content: @Composable () -> Unit = {},
 ) {
 
     val focusManager = LocalFocusManager.current

--- a/app/src/main/java/com/soopeach/dowith/ui/component/button/DoWithButton.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/component/button/DoWithButton.kt
@@ -1,0 +1,35 @@
+package com.soopeach.dowith.ui.component.button
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.soopeach.dowith.ui.theme.DoWithColors
+import com.soopeach.dowith.ui.theme.DoWithTypography
+
+@Composable
+fun DoWithButton(
+    modifier: Modifier = Modifier,
+    text: String,
+    onButtonClicked: () -> Unit = {}
+) {
+    Button(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(48.dp),
+        shape = RoundedCornerShape(12.dp),
+        onClick = { onButtonClicked() },
+        colors = ButtonDefaults.buttonColors(backgroundColor = DoWithColors.gray800),
+    ) {
+        Text(
+            text = text,
+            style = DoWithTypography.Body3.copy(Color.White)
+        )
+    }
+}

--- a/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMainScreen.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMainScreen.kt
@@ -77,20 +77,13 @@ fun PersonalTodoMainContent(
             Spacer(modifier = Modifier.height(54.dp))
 
             state.todayTodoItems.getDataOrNull()?.let { todoItems ->
-                if (todoItems.isEmpty()) {
 
-                    SimplifiedTodoContainer(
-                        onMoreClicked = onMoreClicked
-                    ) {
+                SimplifiedTodoContainer(
+                    onMoreClicked = onMoreClicked
+                ) {
+                    if (todoItems.isEmpty()) {
                         DoWithButton(text = "작성하러 가기")
-                    }
-
-
-                } else {
-
-                    SimplifiedTodoContainer(
-                        onMoreClicked = onMoreClicked
-                    ) {
+                    } else {
                         todoItems.forEach {
                             TodoItemComposable(
                                 todoItem = it,
@@ -100,7 +93,6 @@ fun PersonalTodoMainContent(
                                     onTodoItemClicked(it.id)
                                 }
                             )
-
                             Spacer(modifier = Modifier.height(16.dp))
                         }
                     }

--- a/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMainScreen.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMainScreen.kt
@@ -7,10 +7,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Scaffold
+import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -19,10 +23,13 @@ import com.soopeach.dowith.ui.component.button.DoWithButton
 import com.soopeach.dowith.ui.component.DoWithTopBar
 import com.soopeach.dowith.ui.component.SimplifiedTodoContainer
 import com.soopeach.dowith.ui.component.TodoItemComposable
+import com.soopeach.dowith.ui.component.bottomsheet.TodoContainerModalBottomSheetLayout
+import com.soopeach.dowith.ui.component.bottomsheet.TodoContainerModalBottomSheetType
 import com.soopeach.dowith.ui.screen.Screen
 import com.soopeach.dowith.ui.theme.DoWithColors
 import com.soopeach.dowith.viewmodel.PersonalTodoMainState
 import com.soopeach.dowith.viewmodel.PersonalTodoMainViewModel
+import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.compose.collectAsState
 
 @Composable
@@ -44,56 +51,85 @@ fun PersonalTodoMainScreen(
         },
         onMoreClicked = {
             navController.navigate(Screen.PersonalTodoMore.route)
+        },
+        onCompleteButtonClicked = { todoContents ->
+            todoContents.forEach { content ->
+                viewModel.postTodoItem(content)
+            }
         }
     )
 
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun PersonalTodoMainContent(
     state: PersonalTodoMainState,
     onTodoItemClicked: (Long) -> Unit = {},
-    onMoreClicked: () -> Unit = {}
+    onMoreClicked: () -> Unit = {},
+    onCompleteButtonClicked: (List<String>) -> Unit = {}
 ) {
-    Scaffold(
-        topBar = {
-            DoWithTopBar()
-        }) { paddingValues ->
 
-        Column(
-            modifier = Modifier
-                .padding(paddingValues = paddingValues)
-                .padding(20.dp)
+    val bottomSheetScope = rememberCoroutineScope()
 
-        ) {
+    val bottomSheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden,
+        confirmValueChange = { it != ModalBottomSheetValue.HalfExpanded },
+        skipHalfExpanded = true
+    )
 
-            Box(
+    TodoContainerModalBottomSheetLayout(
+        bottomSheetType = TodoContainerModalBottomSheetType.Write,
+        coroutineScope = bottomSheetScope,
+        modalSheetState = bottomSheetState,
+        onCompleteButtonClicked = {
+            onCompleteButtonClicked(it)
+        }
+    ) {
+        Scaffold(
+            topBar = {
+                DoWithTopBar()
+            }) { paddingValues ->
+
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .height(380.dp)
-                    .background(DoWithColors.gray200)
-            )
+                    .padding(paddingValues = paddingValues)
+                    .padding(20.dp)
 
-            Spacer(modifier = Modifier.height(54.dp))
+            ) {
 
-            state.todayTodoItems.getDataOrNull()?.let { todoItems ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(380.dp)
+                        .background(DoWithColors.gray200)
+                )
 
-                SimplifiedTodoContainer(
-                    onMoreClicked = onMoreClicked
-                ) {
-                    if (todoItems.isEmpty()) {
-                        DoWithButton(text = "작성하러 가기")
-                    } else {
-                        todoItems.forEach {
-                            TodoItemComposable(
-                                todoItem = it,
-                                modifier = Modifier.fillMaxWidth(),
-                                isMoreIconVisible = false,
-                                onTodoIconClicked = {
-                                    onTodoItemClicked(it.id)
+                Spacer(modifier = Modifier.height(54.dp))
+
+                state.todayTodoItems.getDataOrNull()?.let { todoItems ->
+
+                    SimplifiedTodoContainer(
+                        onMoreClicked = onMoreClicked
+                    ) {
+                        if (todoItems.isEmpty()) {
+                            DoWithButton(text = "작성하러 가기") {
+                                bottomSheetScope.launch {
+                                    bottomSheetState.show()
                                 }
-                            )
-                            Spacer(modifier = Modifier.height(16.dp))
+                            }
+                        } else {
+                            todoItems.forEach {
+                                TodoItemComposable(
+                                    todoItem = it,
+                                    modifier = Modifier.fillMaxWidth(),
+                                    isMoreIconVisible = false,
+                                    onTodoIconClicked = {
+                                        onTodoItemClicked(it.id)
+                                    }
+                                )
+                                Spacer(modifier = Modifier.height(16.dp))
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMainScreen.kt
+++ b/app/src/main/java/com/soopeach/dowith/ui/screen/personal/PersonalTodoMainScreen.kt
@@ -15,8 +15,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import com.soopeach.dowith.ui.component.button.DoWithButton
 import com.soopeach.dowith.ui.component.DoWithTopBar
 import com.soopeach.dowith.ui.component.SimplifiedTodoContainer
+import com.soopeach.dowith.ui.component.TodoItemComposable
 import com.soopeach.dowith.ui.screen.Screen
 import com.soopeach.dowith.ui.theme.DoWithColors
 import com.soopeach.dowith.viewmodel.PersonalTodoMainState
@@ -75,12 +77,36 @@ fun PersonalTodoMainContent(
             Spacer(modifier = Modifier.height(54.dp))
 
             state.todayTodoItems.getDataOrNull()?.let { todoItems ->
-                SimplifiedTodoContainer(todoItems.take(2), onTodoIconClicked = {
-                    onTodoItemClicked(it)
-                }) {
-                    onMoreClicked()
+                if (todoItems.isEmpty()) {
+
+                    SimplifiedTodoContainer(
+                        onMoreClicked = onMoreClicked
+                    ) {
+                        DoWithButton(text = "작성하러 가기")
+                    }
+
+
+                } else {
+
+                    SimplifiedTodoContainer(
+                        onMoreClicked = onMoreClicked
+                    ) {
+                        todoItems.forEach {
+                            TodoItemComposable(
+                                todoItem = it,
+                                modifier = Modifier.fillMaxWidth(),
+                                isMoreIconVisible = false,
+                                onTodoIconClicked = {
+                                    onTodoItemClicked(it.id)
+                                }
+                            )
+
+                            Spacer(modifier = Modifier.height(16.dp))
+                        }
+                    }
                 }
             }
         }
     }
 }
+

--- a/app/src/main/java/com/soopeach/dowith/viewmodel/PersonalTodoMainViewModel.kt
+++ b/app/src/main/java/com/soopeach/dowith/viewmodel/PersonalTodoMainViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import com.soopeach.domain.model.TodoItem
 import com.soopeach.domain.usecase.GetTodayTodoItemsUseCase
 import com.soopeach.domain.usecase.PostTodoToggleUseCase
+import com.soopeach.domain.usecase.PostTodoUseCase
 import com.soopeach.dowith.model.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.ContainerHost
@@ -23,7 +24,8 @@ data class PersonalTodoMainState(
 @HiltViewModel
 class PersonalTodoMainViewModel @Inject constructor(
     private val getTodayTodoItemsUseCase: GetTodayTodoItemsUseCase,
-    private val postTodoToggleUseCase: PostTodoToggleUseCase
+    private val postTodoToggleUseCase: PostTodoToggleUseCase,
+    private val postTodoUseCase: PostTodoUseCase
 ) : ViewModel(),
     ContainerHost<PersonalTodoMainState, PersonalTodoMainSideEffect> {
 
@@ -51,6 +53,17 @@ class PersonalTodoMainViewModel @Inject constructor(
                     if (it.id == toggleChangedPost.id) toggleChangedPost else it
                 }
             ))
+        }
+    }
+
+    fun postTodoItem(content: String) = intent {
+        val newTodoItem = postTodoUseCase(content)
+        reduce {
+            state.copy(
+                todayTodoItems = UiState.Success(
+                    previousTodoItems + newTodoItem
+                )
+            )
         }
     }
 


### PR DESCRIPTION
## 개요
- 개인 투두 메인 페이지에서 투두 작성 기능 추가
- SimplifiedTodoContainer 확장성 있도록 변경

## 동작 모습
![main_make_todo](https://github.com/Do-It-Do-It-Chu/Dowith-Android/assets/90144041/2a374b8f-f770-4eec-a06c-783f249dfcb7)
